### PR TITLE
fix: Fix type coercion for array and tuple members

### DIFF
--- a/sysroot/std/fmt.alu
+++ b/sysroot/std/fmt.alu
@@ -426,6 +426,16 @@ mod internal {
             fmt.write_str(s)
         }
     }
+
+    struct CharAdapter {
+        inner: u8
+    }
+
+    impl CharAdapter {
+        fn fmt<F: Formatter<F>>(self: &CharAdapter, fmt: &mut F) -> Result {
+            fmt.write_byte(self.inner)
+        }
+    }
 }
 
 /// Write value as a hexadecimal number
@@ -504,6 +514,20 @@ fn pad_with<T: Formattable<T>>(val: T, len: usize, pad: u8) -> internal::Generic
     internal::GenericPadAdapter { len: len, pad: pad, inner: val }
 }
 
+/// Writes a single [u8] as a character (byte).
+///
+/// By default, [u8] is written as a number.
+///
+/// ## Example
+/// ```
+/// use std::fmt::char;
+///
+/// println!("{}", 'A'); // prints '65'
+/// println!("{}", 'A'.char()); // prints 'A'
+/// ```
+fn char(val: u8) -> internal::CharAdapter {
+    internal::CharAdapter { inner: val }
+}
 
 #[cfg(all(test, test_std))]
 #[docs(hide)]

--- a/sysroot/std/mem.alu
+++ b/sysroot/std/mem.alu
@@ -646,10 +646,10 @@ fn alloc_zeroed<T>() -> &mut T {
 /// Allocates an array of specified size on the stack.
 ///
 /// The values are not initialized. The array is allocated on the stack, so it will be
-/// deallocated when the function returns. 
+/// deallocated when the function returns.
 ///
 /// Care must be taken to ensure that the array is not accessed after the function returns.
-/// Additionally, there is no protection against stack overflow, so allocated arrays should 
+/// Additionally, there is no protection against stack overflow, so allocated arrays should
 /// not be too large.
 ///
 /// ## Example
@@ -673,6 +673,7 @@ fn stack_alloc<T>(len: usize) -> &mut [T] {
     slice::from_raw(when T: builtins::ZeroSized {
         dangling::<&mut T>()
     } else {
+        // Cannot use __builtin_alloca_with_align as it may not be valid until the end of the function
         intrinsics::codegen_func::<&mut void>(
             "__builtin_alloca",
             size_of::<T>() * len

--- a/sysroot/std/panicking.alu
+++ b/sysroot/std/panicking.alu
@@ -111,9 +111,12 @@ mod internal {
                 use string::{starts_with, is_digit};
                 use option::try;
 
+                if name.starts_with("_AL0") {
+                    return Option::some("<anonymous>");
+                }
+
                 if !name.starts_with("_AL")
                     || name.len() < 5
-                    || name[3] == '0'
                     || !name[3].is_digit() {
                     return Option::none();
                 }

--- a/sysroot/std/runtime.alu
+++ b/sysroot/std/runtime.alu
@@ -79,7 +79,6 @@ mod internal {
         let argc = $argc as usize;
 
         if argc > STACK_ARGS_MAX {
-            // Cannot use __builtin_alloca_with_align as it may not be valid until the end of the function
             mem::stack_alloc::<&[u8]>(argc)
         } else {
             mem::slice::alloc::<&[u8]>(argc)

--- a/sysroot/std/string/unicode.alu
+++ b/sysroot/std/string/unicode.alu
@@ -18,13 +18,15 @@ enum Error {
 }
 
 impl Error {
+    use fmt::{Formatter, Result};
+
     /// @ cmp::Equatable::equals
     fn equals(self: &Error, other: &Error) -> bool {
         *self == *other
     }
 
     /// @ fmt::Formattable::fmt
-    fn fmt<F: fmt::Formatter<F>>(self: &Error, f: &mut F) -> fmt::Result {
+    fn fmt<F: Formatter<F>>(self: &Error, f: &mut F) -> Result {
         switch *self {
             Error::BufferTooSmall => f.write_str("buffer too small"),
             Error::InvalidCodepoint => f.write_str("invalid codepoint"),
@@ -492,6 +494,55 @@ fn chars(self: &[u8]) -> CharsIterator {
 fn char_indices(self: &[u8]) -> CharIndicesIterator {
     CharIndicesIterator {
         _inner: internal::UTF8CodepointIterator::new(self)
+    }
+}
+
+/// Returns a formattable object that writes a sequence of
+/// Unicode codepoints as a UTF-8 encoded string.
+///
+/// It accepts an iterator over `u32` values. Panics if the iterator
+/// yields a value that is not a valid Unicode scalar value.
+///
+/// ## Example
+/// ```
+/// use std::string::unicode::utf8_chars;
+///
+/// let seq = [
+///     0x1f4a9u32,
+///     '=' as u32,
+///     0x1fa99,
+///     ' ' as u32,
+///     '&' as u32,
+///     ' ' as u32,
+///     0x1fa99,
+///     '=' as u32,
+///     0x1f4a9
+/// ];
+///
+/// // https://sl.wikisource.org/wiki/Kons._5
+/// println!("{}", seq.iter().utf8_chars()); // prints "💩=🪙 & 💩=🪙"
+/// ```
+fn utf8_chars<It: iter::Iterator<It, u32>>(iter: &mut It) -> Utf8Adapter<It> {
+    Utf8Adapter { inner: iter }
+}
+
+struct Utf8Adapter<It: iter::Iterator<It, u32>> {
+    inner: &mut It
+}
+
+impl Utf8Adapter<It: iter::Iterator<It, u32>> {
+    use fmt::{Formatter, Result};
+
+    fn fmt<F: Formatter<F>>(self: &Utf8Adapter<It>, f: &mut F) -> Result {
+        let buf: [u8; 4];
+        let codepoint = self.inner.next();
+        if codepoint.is_none() {
+            return Result::ok(());
+        }
+
+        let codepoint = codepoint.unwrap();
+        let len = codepoint.encode_utf8(&buf).unwrap();
+        f.write_str(buf[..len])
     }
 }
 


### PR DESCRIPTION
This change allows the type hint to be used to coerce array and tuple members into the correct type, for example:

```rust
protocol Foo<Self> {}
struct Bar {}
struct Quux {}

let a: [&dyn Foo<Self>; 2] = [&Bar {}, &Quux {}];
let b: (&dyn Foo<Self>, &dyn Foo<Self>) = (&Bar {}, &Quux {});
```

Also adds some conveniece adapter for formatting characters and UTF-8.