### PR TITLE
refactor: Move ZstElider from mono to codegen stage

### DIFF
--- a/MISSING.md
+++ b/MISSING.md
@@ -26,6 +26,7 @@
 - a coherent story for operator overloading
 - `dyn` pointers for certain builtin protocols. Specifically `dyn Callable<...>` would be very useful for being type-erased closures.
 - docstrings for fields and enum variants
+- Fix that damn "local with unkown type" issue. It can happen that compilation will fail with 0 errors and 0 warnings now.
 
 ## Grammar, parsing, AST
 
@@ -62,6 +63,7 @@
   - date/time???? this is a big can of worms
     - durations/monotonic timer are implemented
   - regexes? probably not, maybe a PCRE wrapper outside stdlib
+  - JSON? Some sort of Serde-like generic serialization/deserialization would be nice to have built-in
 
 ## Optimizations
 
@@ -99,13 +101,9 @@
 - Cross-compilation
   - Should be easy enough, as generated C code has almost no platform dependencies. This is more of a concern for the standard library to ensure `cfg` attributes are sprinkled around appropriately.
     - const eval needs to adjust usizes etc. to the target platform
-- Logging, timings
 
 ## Exploratory
 
-- specialization/SFINAE/function overloading?
-  - I am leaning pretty strongly towards not having either of these. With protocols the language
-    is expressive enough to do string formatting, iterators and collections, which are a good litmus test if generics are any good.
 - tagged unions
   - I miss them quite a lot from Rust. They are not hard, but need a good syntax for `match`
 - full Hindley-Milner type inference. Global type inference will pretty much require a full rewrite of `mono`, so whis would be a massive project, but it would also be super awesome to have
@@ -119,6 +117,8 @@
 ## Tooling
 
 - a compiler driver (i.e. Cargo)
+- integrated codegen (a la `go generate` or procedural macros)
+- a REPL. Totally doable with const-eval.
 
 ## Bikeshedding
 
@@ -126,4 +126,5 @@
   - This is settled now. See: Rust.
 - Why "Alumina"?
   - Because it's another metal oxide, like Rust
-    - Rust begets more Rust until everything is oxidized. Aluminium forms just a thin passivation layer leaving "bare metal" just under the surface.
+  - Rust begets more Rust until everything is oxidized. Aluminium forms just a thin passivation layer leaving "bare metal" just under the surface.
+  -

--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,7 @@ quick: $(BUILD_DIR)/quick
 
 ## ------------------------------ Benchmarking -------------------------
 
-.PHONY: bench-std bench-std-cc
+.PHONY: bench-std bench-std-cc flamegraph
 
 BENCH_CMD = ./tools/bench.py -n$(if $(TIMES),$(TIMES),20) $(if $(MARKDOWN),--markdown,)
 
@@ -261,6 +261,12 @@ bench-std: $(ALUMINA_BOOT) $(SYSROOT_FILES)
 
 bench-std-cc: $(STDLIB_TESTS).c
 	$(BENCH_CMD) $(CC) $(CFLAGS) -o/dev/null $^ $(LDFLAGS)
+
+$(BUILD_DIR)/flamegraph.svg: $(ALUMINA_BOOT) $(SYSROOT_FILES)
+	CARGO_PROFILE_RELEASE_DEBUG=true cargo flamegraph \
+		-o $@ -- $(ALUMINA_FLAGS) --timings --cfg test --cfg test_std --output /dev/null
+
+flamegraph: $(BUILD_DIR)/flamegraph.svg
 
 ## ------------------------------ Coverage ------------------------------
 .PHONY: coverage dist-check-with-coverage

--- a/docs/lang_guide.md
+++ b/docs/lang_guide.md
@@ -330,12 +330,10 @@ let arr: [u32; QUUX];
 
 Constant evaluation supports many of the language features, including variable assignments, loops, conditionals, function calls, etc. Functions do not have to be specifically marked as `const` or `constexpr` in order to use them in constant expressions. The following are not supported:
 
-- arithmetic operations and comparisons of floating point numbers
 - foreign function calls, including `libc` functions
 - inline assembly and most other compiler intrinsics
-- atomic operations
-- `dyn` pointers and virtual dispatch
-- type punning of any sort (e.g. via a union, `std::util::transmute` or pointer casts)
+- type punning (via `transmute`, `union` or pointer casts)
+    - exception: transmuting integers of same size and floating point numbers to integers and back is supported
 - pointer arithmetic between pointers of different provenance
   ```rust
   const _ = {
@@ -346,6 +344,7 @@ Constant evaluation supports many of the language features, including variable a
         let diff2 = &a[7] - &b[3]; // but this is not
   }
   ```
+- converting between pointers and integers
 - all operations[^1] that would cause undefined behavior at runtime (out of bounds array access, signed overflow, division by zero, reaching `std::unreachable()`, etc.)
   - uninitialized memory is not forbidden - a constant is allowed e.g. to evaluate to a struct with an uninitialized field, but if the uninitialized value is used for computation during constant evaluation itself, this will result in a compile-time error.
     ```rust
@@ -360,7 +359,7 @@ Constant evaluation supports many of the language features, including variable a
 
 Call to `std::runtime::in_const_context` function evaluates to `true` during constant evaluation and `false` during code generation. This can be used to make functions const-compatible (e.g. by using an implementation not relying on foreign functions).
 
-There are also limits on how complex a constant expression can be. The compiler will reject constant expressions that are too complex to evaluate at compile time. The current hard-coded limits is 10000 steps and a maximum recursion depth of 100 per constant expression.
+There are also limits on how complex a constant expression can be. The compiler will reject constant expressions that are too complex to evaluate at compile time. The current hard-coded limits are 10000 steps and a maximum recursion depth of 100 per constant expression.
 
 [^1]: If you can produce UB during const-eval, please file a bug.
 

--- a/src/alumina-boot/src/ast/format.rs
+++ b/src/alumina-boot/src/ast/format.rs
@@ -1,4 +1,4 @@
-use crate::common::{AluminaError, CodeErrorBuilder, CodeErrorKind, HashSet};
+use crate::common::{AluminaError, CodeDiagnostic, CodeErrorBuilder, HashSet};
 
 use super::Span;
 
@@ -39,7 +39,7 @@ pub fn format_args(
                     .ok()
                     .and_then(|idx| idx.parse().ok())
                     .ok_or_else(|| {
-                        CodeErrorKind::InvalidFormatString("invalid argument index".to_string())
+                        CodeDiagnostic::InvalidFormatString("invalid argument index".to_string())
                     })
                     .with_span(span)?
             } else {
@@ -53,7 +53,7 @@ pub fn format_args(
             }
 
             if num_args <= index {
-                return Err(CodeErrorKind::InvalidFormatString(
+                return Err(CodeDiagnostic::InvalidFormatString(
                     "not enough arguments".to_string(),
                 ))
                 .with_span(span);
@@ -80,7 +80,7 @@ pub fn format_args(
                     State::Normal
                 }
                 _ => {
-                    return Err(CodeErrorKind::InvalidFormatString(format!(
+                    return Err(CodeDiagnostic::InvalidFormatString(format!(
                         "unexpected {:?}",
                         ch as char
                     )))
@@ -97,7 +97,7 @@ pub fn format_args(
                     State::Normal
                 }
                 _ => {
-                    return Err(CodeErrorKind::InvalidFormatString(format!(
+                    return Err(CodeDiagnostic::InvalidFormatString(format!(
                         "unexpected {:?}",
                         ch as char
                     )))
@@ -118,7 +118,7 @@ pub fn format_args(
                     State::Index
                 }
                 _ => {
-                    return Err(CodeErrorKind::InvalidFormatString(format!(
+                    return Err(CodeDiagnostic::InvalidFormatString(format!(
                         "unexpected {:?}",
                         ch as char
                     )))
@@ -129,14 +129,14 @@ pub fn format_args(
     }
 
     if state != State::Normal {
-        return Err(CodeErrorKind::InvalidFormatString(
+        return Err(CodeDiagnostic::InvalidFormatString(
             "unexpected end of format string".to_string(),
         ))
         .with_span(span);
     }
 
     if num_args > used_arguments.len() {
-        return Err(CodeErrorKind::InvalidFormatString(
+        return Err(CodeDiagnostic::InvalidFormatString(
             "unused arguments".to_string(),
         ))
         .with_span(span);

--- a/src/alumina-boot/src/ast/lang.rs
+++ b/src/alumina-boot/src/ast/lang.rs
@@ -1,5 +1,5 @@
 use crate::ast::{BinOp, BuiltinType};
-use crate::common::CodeErrorKind;
+use crate::common::CodeDiagnostic;
 use crate::utils::regex;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -132,7 +132,7 @@ impl LangItemKind {
 }
 
 impl TryFrom<&str> for LangItemKind {
-    type Error = CodeErrorKind;
+    type Error = CodeDiagnostic;
 
     fn try_from(s: &str) -> Result<Self, Self::Error> {
         match s {
@@ -239,7 +239,7 @@ impl TryFrom<&str> for LangItemKind {
                     let n = matches[1].parse::<usize>().unwrap();
                     Ok(LangItemKind::ImplTuple(n))
                 } else {
-                    Err(CodeErrorKind::UnknownLangItem(Some(t.to_string())))
+                    Err(CodeDiagnostic::UnknownLangItem(Some(t.to_string())))
                 }
             }
         }

--- a/src/alumina-boot/src/ast/macros.rs
+++ b/src/alumina-boot/src/ast/macros.rs
@@ -5,7 +5,7 @@ use crate::ast::{
     AstCtx, AstId, Attribute, BuiltinMacro, BuiltinMacroKind, Expr, ExprKind, ExprP,
     FieldInitializer, FnKind, Item, ItemP, Lit, Macro, MacroCtx, MacroParameter, Span, Statement,
 };
-use crate::common::{AluminaError, ArenaAllocatable, CodeErrorKind, HashMap};
+use crate::common::{AluminaError, ArenaAllocatable, CodeDiagnostic, HashMap};
 use crate::global_ctx::GlobalCtx;
 use crate::name_resolution::scope::{NamedItemKind, Scope};
 use crate::parser::{FieldKind, NodeExt};
@@ -23,7 +23,7 @@ macro_rules! assert_args {
     ($self:expr, $count:expr) => {
         if $self.args.len() != $count {
             use crate::common::CodeErrorBuilder;
-            return Err(CodeErrorKind::ParamCountMismatch($count, $self.args.len()))
+            return Err(CodeDiagnostic::ParamCountMismatch($count, $self.args.len()))
                 .with_span($self.invocation_span);
         }
     };
@@ -35,7 +35,8 @@ macro_rules! string_arg {
             ExprKind::Lit(Lit::Str(s)) => s,
             _ => {
                 use crate::common::CodeErrorBuilder;
-                return Err(CodeErrorKind::ConstantStringExpected).with_span($self.invocation_span);
+                return Err(CodeDiagnostic::ConstantStringExpected)
+                    .with_span($self.invocation_span);
             }
         }
     };
@@ -47,7 +48,7 @@ macro_rules! macro_arg {
             ExprKind::Macro(item, bound_args) => (item, bound_args),
             _ => {
                 use crate::common::CodeErrorBuilder;
-                return Err(CodeErrorKind::MacroExpected).with_span($self.invocation_span);
+                return Err(CodeDiagnostic::MacroExpected).with_span($self.invocation_span);
             }
         }
     };
@@ -74,7 +75,8 @@ impl<'ast> MacroMaker<'ast> {
                     if m.body.get().is_some() {
                         return Ok(());
                     } else {
-                        return Err(CodeErrorKind::RecursiveMacroCall).with_span_from(&scope, node);
+                        return Err(CodeDiagnostic::RecursiveMacroCall)
+                            .with_span_from(&scope, node);
                     }
                 }
                 Item::BuiltinMacro(_) => {
@@ -92,6 +94,7 @@ impl<'ast> MacroMaker<'ast> {
         if attributes.iter().any(|a| matches!(a, Attribute::Builtin)) {
             let kind = match name.unwrap() {
                 "env" => BuiltinMacroKind::Env,
+                "cfg" => BuiltinMacroKind::Cfg,
                 "include_bytes" => BuiltinMacroKind::IncludeBytes,
                 "concat" => BuiltinMacroKind::Concat,
                 "line" => BuiltinMacroKind::Line,
@@ -102,7 +105,7 @@ impl<'ast> MacroMaker<'ast> {
                 "reduce" => BuiltinMacroKind::Reduce,
                 "stringify" => BuiltinMacroKind::Stringify,
                 s => {
-                    return Err(CodeErrorKind::UnknownBuiltinMacro(s.to_string()))
+                    return Err(CodeDiagnostic::UnknownBuiltinMacro(s.to_string()))
                         .with_span_from(&scope, node)
                 }
             };
@@ -119,7 +122,7 @@ impl<'ast> MacroMaker<'ast> {
             match item.kind {
                 NamedItemKind::MacroParameter(id, et_cetera, _) => {
                     if has_et_cetera && et_cetera {
-                        return Err(CodeErrorKind::MultipleEtCeteras).with_span_from(&scope, node);
+                        return Err(CodeDiagnostic::MultipleEtCeteras).with_span_from(&scope, node);
                     } else if et_cetera {
                         has_et_cetera = true;
                     }
@@ -213,7 +216,7 @@ impl<'ast> MacroExpander<'ast> {
 
         if let Some(et_cetera_index) = et_cetera_index {
             if self.args.len() < r#macro.args.len() - 1 {
-                return Err(CodeErrorKind::NotEnoughMacroArguments(
+                return Err(CodeDiagnostic::NotEnoughMacroArguments(
                     r#macro.args.len() - 1,
                 ))
                 .with_span(self.invocation_span);
@@ -234,7 +237,7 @@ impl<'ast> MacroExpander<'ast> {
             self.et_cetera_arg = Some((r#macro.args[et_cetera_index].id, etc_args));
         } else {
             if self.args.len() != r#macro.args.len() {
-                return Err(CodeErrorKind::ParamCountMismatch(
+                return Err(CodeDiagnostic::ParamCountMismatch(
                     r#macro.args.len(),
                     self.args.len(),
                 ))
@@ -256,7 +259,7 @@ impl<'ast> MacroExpander<'ast> {
         for arg in args {
             if let super::ExprKind::EtCetera(inner) = arg.kind {
                 if self.et_cetera_index.is_some() {
-                    return Err(CodeErrorKind::EtCeteraInEtCetera).with_span(arg.span);
+                    return Err(CodeDiagnostic::EtCeteraInEtCetera).with_span(arg.span);
                 }
                 for idx in 0..self.et_cetera_arg.as_ref().unwrap().1.len() {
                     self.et_cetera_index = Some(idx);
@@ -349,7 +352,7 @@ impl<'ast> MacroExpander<'ast> {
                 let inner = self.visit_expr(inner)?;
                 let (item, bound_args) = match inner.kind {
                     ExprKind::Macro(m, b) => (m, b),
-                    _ => return Err(CodeErrorKind::NotAMacro).with_span(inner.span),
+                    _ => return Err(CodeDiagnostic::NotAMacro).with_span(inner.span),
                 };
                 let child = MacroExpander::new(
                     self.ast,
@@ -372,7 +375,7 @@ impl<'ast> MacroExpander<'ast> {
                     if let Some(index) = self.et_cetera_index {
                         return Ok(self.et_cetera_arg.as_ref().unwrap().1[index]);
                     } else {
-                        return Err(CodeErrorKind::CannotEtCeteraHere).with_span(expr.span);
+                        return Err(CodeDiagnostic::CannotEtCeteraHere).with_span(expr.span);
                     }
                 } else {
                     let id = match self.id_replacements.get(&id) {
@@ -387,7 +390,7 @@ impl<'ast> MacroExpander<'ast> {
                 }
             }
             EtCetera(_) => {
-                return Err(CodeErrorKind::CannotEtCeteraHere).with_span(expr.span);
+                return Err(CodeDiagnostic::CannotEtCeteraHere).with_span(expr.span);
             }
             Block(statements, ret) => {
                 let mut new_statements = Vec::new();
@@ -398,7 +401,7 @@ impl<'ast> MacroExpander<'ast> {
                     }) = statement.kind
                     {
                         if self.et_cetera_index.is_some() {
-                            return Err(CodeErrorKind::EtCeteraInEtCetera).with_span(*span);
+                            return Err(CodeDiagnostic::EtCeteraInEtCetera).with_span(*span);
                         }
                         for idx in 0..self.et_cetera_arg.as_ref().unwrap().1.len() {
                             self.et_cetera_index = Some(idx);
@@ -511,6 +514,7 @@ impl<'ast> MacroExpander<'ast> {
 
                 Const(item, generic_args)
             }
+            Tag(tag, inner) => Tag(tag, self.visit_expr(inner)?),
             Continue
             | EnumValue(_, _)
             | Macro(_, _ /* bound values are "invisible" and should not be replaced */)
@@ -591,7 +595,7 @@ impl<'ast> MacroExpander<'ast> {
                 let (line, column) = self
                     .invocation_span
                     .map(|s| (s.line + 1, s.column + 1))
-                    .ok_or(CodeErrorKind::NoSpanInformation)
+                    .ok_or(CodeDiagnostic::NoSpanInformation)
                     .with_span(self.invocation_span)?;
 
                 let kind = if let BuiltinMacroKind::Line = kind {
@@ -620,7 +624,7 @@ impl<'ast> MacroExpander<'ast> {
                                     .alloc_slice_copy(filename.to_string_lossy().as_bytes())
                             })
                     })
-                    .ok_or(CodeErrorKind::NoSpanInformation)
+                    .ok_or(CodeDiagnostic::NoSpanInformation)
                     .with_span(self.invocation_span)?;
 
                 let kind = ExprKind::Lit(Lit::Str(filename));
@@ -638,7 +642,7 @@ impl<'ast> MacroExpander<'ast> {
                 };
 
                 let data = std::fs::read(filename)
-                    .map_err(|_| CodeErrorKind::CannotReadFile(filename.to_string()))
+                    .map_err(|_| CodeDiagnostic::CannotReadFile(filename.to_string()))
                     .with_span(self.invocation_span)?;
 
                 Ok(Expr {
@@ -653,7 +657,7 @@ impl<'ast> MacroExpander<'ast> {
                     .iter()
                     .map(|arg| match arg.kind {
                         ExprKind::Lit(Lit::Str(s)) => Ok(s),
-                        _ => Err(CodeErrorKind::ConstantStringExpected)
+                        _ => Err(CodeDiagnostic::ConstantStringExpected)
                             .with_span(self.invocation_span),
                     })
                     .collect::<Result<Vec<_>, _>>()?;
@@ -677,7 +681,7 @@ impl<'ast> MacroExpander<'ast> {
             }
             BuiltinMacroKind::FormatArgs => {
                 if self.args.len() < 2 {
-                    return Err(CodeErrorKind::NotEnoughMacroArguments(2))
+                    return Err(CodeDiagnostic::NotEnoughMacroArguments(2))
                         .with_span(self.invocation_span);
                 }
 
@@ -715,7 +719,7 @@ impl<'ast> MacroExpander<'ast> {
             }
             BuiltinMacroKind::Bind => {
                 if self.args.is_empty() {
-                    return Err(CodeErrorKind::NotEnoughMacroArguments(1))
+                    return Err(CodeDiagnostic::NotEnoughMacroArguments(1))
                         .with_span(self.invocation_span);
                 }
 
@@ -733,7 +737,7 @@ impl<'ast> MacroExpander<'ast> {
             }
             BuiltinMacroKind::Reduce => {
                 if self.args.len() < 2 {
-                    return Err(CodeErrorKind::NotEnoughMacroArguments(2))
+                    return Err(CodeDiagnostic::NotEnoughMacroArguments(2))
                         .with_span(self.invocation_span);
                 }
 
@@ -755,6 +759,18 @@ impl<'ast> MacroExpander<'ast> {
                 }
 
                 Ok(expr)
+            }
+            BuiltinMacroKind::Cfg => {
+                assert_args!(self, 1);
+                let name = string_arg!(self, 0);
+
+                Ok(Expr {
+                    kind: ExprKind::Lit(Lit::Bool(
+                        self.global_ctx.has_flag(std::str::from_utf8(name).unwrap()),
+                    )),
+                    span: self.invocation_span,
+                }
+                .alloc_on(self.ast))
             }
         }
     }

--- a/src/alumina-boot/src/ast/mod.rs
+++ b/src/alumina-boot/src/ast/mod.rs
@@ -9,7 +9,7 @@ pub mod types;
 
 use crate::ast::lang::LangItemKind;
 use crate::common::{
-    impl_allocatable, Allocatable, ArenaAllocatable, CodeErrorKind, FileId, HashMap, HashSet,
+    impl_allocatable, Allocatable, ArenaAllocatable, CodeDiagnostic, FileId, HashMap, HashSet,
     Incrementable,
 };
 use crate::intrinsics::IntrinsicKind;
@@ -59,12 +59,12 @@ impl<'ast> AstCtx<'ast> {
         }
     }
 
-    pub fn lang_item(&self, kind: LangItemKind) -> Result<ItemP<'ast>, CodeErrorKind> {
+    pub fn lang_item(&self, kind: LangItemKind) -> Result<ItemP<'ast>, CodeDiagnostic> {
         self.lang_items
             .borrow()
             .get(&kind)
             .copied()
-            .ok_or(CodeErrorKind::MissingLangItem(kind))
+            .ok_or(CodeDiagnostic::MissingLangItem(kind))
     }
 
     pub fn lang_item_kind(&self, item: ItemP<'ast>) -> Option<LangItemKind> {
@@ -628,6 +628,7 @@ pub enum BuiltinMacroKind {
     Line,
     Column,
     File,
+    Cfg,
     IncludeBytes,
     FormatArgs,
     Bind,
@@ -752,7 +753,7 @@ pub enum UnOp {
     BitNot,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Lit<'ast> {
     Str(&'ast [u8]),
     Int(bool, u128, Option<BuiltinType>),
@@ -830,6 +831,7 @@ pub enum ExprKind<'ast> {
     TypeCheck(ExprP<'ast>, TyP<'ast>),
     StaticIf(ExprP<'ast>, ExprP<'ast>, ExprP<'ast>),
     Cast(ExprP<'ast>, TyP<'ast>),
+    Tag(&'ast str, ExprP<'ast>),
 
     Void,
 }

--- a/src/alumina-boot/src/ast/pretty.rs
+++ b/src/alumina-boot/src/ast/pretty.rs
@@ -526,7 +526,7 @@ impl<'ast> PrettyPrinter<'ast> {
                 }
                 Lit::Float(val, kind) => {
                     let mut s = String::new();
-                    s.push_str(val.as_ref());
+                    write!(s, "{}", val).unwrap();
                     if let Some(kind) = kind {
                         s.push_str(&self.print_builtin_type(*kind));
                     }
@@ -677,6 +677,7 @@ impl<'ast> PrettyPrinter<'ast> {
             }
             // Those will never appear in the AST post-macro expansion
             ExprKind::EtCetera(_) | ExprKind::MacroInvocation(_, _) => unreachable!(),
+            ExprKind::Tag(tag, inner) => format!("/* {} */ {}", tag, self.print_expr(inner)),
         };
 
         if braces {

--- a/src/alumina-boot/src/ast/rebind.rs
+++ b/src/alumina-boot/src/ast/rebind.rs
@@ -266,6 +266,7 @@ impl<'ast> Rebinder<'ast> {
             Local(_) | BoundParam(_, _, _) | Continue | EnumValue(_, _) | Lit(_) | Void => {
                 expr.kind.clone()
             }
+            Tag(tag, inner) => Tag(tag, self.visit_expr(inner)?),
         };
 
         let result = Expr {

--- a/src/alumina-boot/src/ast/types.rs
+++ b/src/alumina-boot/src/ast/types.rs
@@ -2,7 +2,7 @@ use crate::ast::expressions::ExpressionVisitor;
 use crate::ast::{
     AstCtx, Bound, BuiltinType, Defered, ProtocolBounds, ProtocolBoundsKind, Span, Ty, TyP,
 };
-use crate::common::{AluminaError, ArenaAllocatable, CodeErrorKind, WithSpanDuringParsing};
+use crate::common::{AluminaError, ArenaAllocatable, CodeDiagnostic, WithSpanDuringParsing};
 use crate::global_ctx::GlobalCtx;
 use crate::name_resolution::resolver::{ItemResolution, NameResolver};
 use crate::name_resolution::scope::{NamedItemKind, Scope};
@@ -82,7 +82,7 @@ impl<'ast, 'src> TypeVisitor<'ast, 'src> {
                 NamedItemKind::Protocol(ty, _, _) => self.ast.intern_type(Ty::Item(ty)),
                 NamedItemKind::Placeholder(ty, _) => self.ast.intern_type(Ty::Placeholder(ty)),
                 kind => {
-                    return Err(CodeErrorKind::Unexpected(format!("{}", kind)))
+                    return Err(CodeDiagnostic::Unexpected(format!("{}", kind)))
                         .with_span_from(&self.scope, node)
                 }
             },
@@ -234,7 +234,7 @@ impl<'ast, 'src> AluminaVisitor<'src> for TypeVisitor<'ast, 'src> {
         match *base {
             Ty::Item(_) | Ty::Defered(_) => {}
             _ => {
-                return Err(CodeErrorKind::UnexpectedGenericParams)
+                return Err(CodeDiagnostic::UnexpectedGenericParams)
                     .with_span_from(&self.scope, node)
             }
         };

--- a/src/alumina-boot/src/compiler.rs
+++ b/src/alumina-boot/src/compiler.rs
@@ -1,7 +1,7 @@
 use crate::ast::maker::AstItemMaker;
 use crate::ast::{AstCtx, MacroCtx};
 use crate::codegen;
-use crate::common::{AluminaError, ArenaAllocatable, CodeErrorBuilder, CodeErrorKind, HashSet};
+use crate::common::{AluminaError, ArenaAllocatable, CodeDiagnostic, CodeErrorBuilder, HashSet};
 use crate::global_ctx::GlobalCtx;
 use crate::ir::dce::DeadCodeEliminator;
 use crate::ir::mono::{MonoCtx, Monomorphizer};
@@ -105,7 +105,7 @@ impl Compiler {
 
                 if let Some(candidate) = visitor.main_candidate() {
                     if main_candidate.replace(candidate).is_some() {
-                        return Err(CodeErrorKind::MultipleMainFunctions)
+                        return Err(CodeDiagnostic::MultipleMainFunctions)
                             .with_span(candidate.get_function().span);
                     }
                 }
@@ -188,7 +188,7 @@ impl Compiler {
         // Dunno why the borrow checker is not letting me do that, it should be possible.
         // drop(ast);
 
-        let res = codegen::codegen(self.global_ctx.clone(), &items[..]);
+        let res = codegen::codegen(&ir_ctx, self.global_ctx.clone(), &items[..]);
         timing!(self, cur_time, Stage::Codegen);
 
         res

--- a/src/alumina-boot/src/diagnostics.rs
+++ b/src/alumina-boot/src/diagnostics.rs
@@ -1,6 +1,6 @@
 use crate::ast::Span;
 use crate::common::{
-    AluminaError, CodeError, CodeErrorKind, FileId, HashMap, HashSet, IndexSet, Marker,
+    AluminaError, CodeDiagnostic, CodeError, FileId, HashMap, HashSet, IndexSet, Marker,
 };
 use crate::ir::const_eval::ConstEvalErrorKind;
 use colored::Colorize;
@@ -108,21 +108,21 @@ impl DiagnosticsStack {
         markers
     }
 
-    pub fn err(&self, kind: CodeErrorKind) -> AluminaError {
+    pub fn err(&self, kind: CodeDiagnostic) -> AluminaError {
         AluminaError::CodeErrors(vec![CodeError {
             kind,
             backtrace: self.materialize(),
         }])
     }
 
-    pub fn warn(&self, kind: CodeErrorKind) {
+    pub fn warn(&self, kind: CodeDiagnostic) {
         self.diag_ctx.add_warning(CodeError {
             kind,
             backtrace: self.materialize(),
         });
     }
 
-    pub fn note(&self, kind: CodeErrorKind) {
+    pub fn note(&self, kind: CodeDiagnostic) {
         self.diag_ctx.add_note(CodeError {
             kind,
             backtrace: self.materialize(),
@@ -294,7 +294,7 @@ impl DiagnosticContext {
             /*
 
             if let CodeError {
-                kind: CodeErrorKind::LocalWithUnknownType,
+                kind: CodeDiagnostic::LocalWithUnknownType,
                 ..
             } = error
             {
@@ -359,8 +359,9 @@ impl DiagnosticContext {
             }
 
             match &error.kind {
-                CodeErrorKind::InternalError(_, backtrace)
-                | CodeErrorKind::CannotConstEvaluate(ConstEvalErrorKind::CompilerBug(backtrace)) => {
+                CodeDiagnostic::InternalError(_, backtrace)
+                | CodeDiagnostic::CannotConstEvaluate(ConstEvalErrorKind::CompilerBug(backtrace)) =>
+                {
                     eprintln!();
                     eprintln!("Compiler backtrace:");
                     eprintln!("{}", backtrace);

--- a/src/alumina-boot/src/intrinsics.rs
+++ b/src/alumina-boot/src/intrinsics.rs
@@ -8,6 +8,7 @@ pub enum IntrinsicKind {
     TypeId,
     TypeName,
     Trap,
+    Transmute,
     CompileFail,
     CompileWarn,
     CompileNote,
@@ -30,6 +31,7 @@ pub enum IntrinsicKind {
     ConstNote,
     ConstAlloc,
     ConstFree,
+    Tag,
 }
 
 pub fn intrinsic_kind(name: &str) -> Option<IntrinsicKind> {
@@ -40,6 +42,7 @@ pub fn intrinsic_kind(name: &str) -> Option<IntrinsicKind> {
         "type_id" => IntrinsicKind::TypeId,
         "type_name" => IntrinsicKind::TypeName,
         "trap" => IntrinsicKind::Trap,
+        "transmute" => IntrinsicKind::Transmute,
         "compile_fail" => IntrinsicKind::CompileFail,
         "compile_warn" => IntrinsicKind::CompileWarn,
         "compile_note" => IntrinsicKind::CompileNote,
@@ -62,6 +65,7 @@ pub fn intrinsic_kind(name: &str) -> Option<IntrinsicKind> {
         "const_note" => IntrinsicKind::ConstNote,
         "const_alloc" => IntrinsicKind::ConstAlloc,
         "const_free" => IntrinsicKind::ConstFree,
+        "tag" => IntrinsicKind::Tag,
         _ => return None,
     };
 
@@ -75,6 +79,7 @@ pub enum IntrinsicValueKind<'ir> {
     Asm(&'ir str),
     FunctionLike(&'ir str),
     ConstLike(&'ir str),
+    Transmute(ExprP<'ir>),
     ConstPanic(ExprP<'ir>),
     ConstWrite(ExprP<'ir>, bool),
     ConstAlloc(TyP<'ir>, ExprP<'ir>),

--- a/src/alumina-boot/src/ir/builder.rs
+++ b/src/alumina-boot/src/ir/builder.rs
@@ -284,6 +284,18 @@ impl<'ir> ExpressionBuilder<'ir> {
         expr.alloc_on(self.ir)
     }
 
+    pub fn tag(&self, tag: &'_ str, inner: ExprP<'ir>, span: Option<Span>) -> ExprP<'ir> {
+        let expr = Expr {
+            kind: ExprKind::Tag(self.ir.intern_str(tag), inner),
+            value_type: inner.value_type,
+            is_const: inner.is_const,
+            ty: inner.ty,
+            span,
+        };
+
+        expr.alloc_on(self.ir)
+    }
+
     pub fn dangling(&self, typ: TyP<'ir>, span: Option<Span>) -> ExprP<'ir> {
         if let Ty::Pointer(ty, _) = typ {
             self.codegen_intrinsic(IntrinsicValueKind::Dangling(ty), typ, span)

--- a/src/alumina-boot/src/ir/const_eval.rs
+++ b/src/alumina-boot/src/ir/const_eval.rs
@@ -1,14 +1,16 @@
 /// An interpreter for constant expressions. It's quite slow.
 use crate::ast::BinOp;
 use crate::common::{
-    AluminaError, ArenaAllocatable, ByRef, CodeError, CodeErrorBuilder, CodeErrorKind, HashMap,
+    AluminaError, ArenaAllocatable, ByRef, CodeDiagnostic, CodeError, CodeErrorBuilder, HashMap,
 };
 use crate::diagnostics::DiagnosticsStack;
+use crate::global_ctx::GlobalCtx;
 use crate::intrinsics::IntrinsicValueKind;
 use crate::ir::{BuiltinType, ExprKind, ExprP, IRItem, IrCtx, IrId, Statement, Ty, TyP, UnOp};
 use std::backtrace::Backtrace;
 use std::cell::RefCell;
 use std::cmp::Ordering;
+use std::hash::Hash;
 use std::num::TryFromIntError;
 use std::ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Neg, Not, Rem, Shl, Shr, Sub};
 use std::rc::Rc;
@@ -18,7 +20,7 @@ use thiserror::Error;
 const MAX_RECURSION_DEPTH: usize = 100;
 const MAX_ITERATIONS: usize = 10000;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy)]
 pub enum Value<'ir> {
     Void,
     Uninitialized,
@@ -35,15 +37,147 @@ pub enum Value<'ir> {
     I128(i128),
     USize(usize),
     ISize(isize),
-    F32(&'ir str),
-    F64(&'ir str),
-    Str(&'ir [u8], usize),
+    F32(f32),
+    F64(f64),
+    Bytes(&'ir [u8], usize),
     Tuple(&'ir [Value<'ir>]),
     Array(&'ir [Value<'ir>]),
     Struct(&'ir [(IrId, Value<'ir>)]),
     FunctionPointer(super::IRItemP<'ir>),
-    Pointer(LValue<'ir>),
+    Pointer(LValue<'ir>, TyP<'ir>),
     LValue(LValue<'ir>),
+}
+
+impl PartialEq for Value<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Value::Void, Value::Void) => true,
+            (Value::Uninitialized, Value::Uninitialized) => true,
+            (Value::Bool(a), Value::Bool(b)) => a == b,
+            (Value::U8(a), Value::U8(b)) => a == b,
+            (Value::U16(a), Value::U16(b)) => a == b,
+            (Value::U32(a), Value::U32(b)) => a == b,
+            (Value::U64(a), Value::U64(b)) => a == b,
+            (Value::U128(a), Value::U128(b)) => a == b,
+            (Value::I8(a), Value::I8(b)) => a == b,
+            (Value::I16(a), Value::I16(b)) => a == b,
+            (Value::I32(a), Value::I32(b)) => a == b,
+            (Value::I64(a), Value::I64(b)) => a == b,
+            (Value::I128(a), Value::I128(b)) => a == b,
+            (Value::USize(a), Value::USize(b)) => a == b,
+            (Value::ISize(a), Value::ISize(b)) => a == b,
+            (Value::F32(a), Value::F32(b)) => a.to_bits() == b.to_bits(),
+            (Value::F64(a), Value::F64(b)) => a.to_bits() == b.to_bits(),
+            (Value::Bytes(a, a_len), Value::Bytes(b, b_len)) => a_len == b_len && a == b,
+            (Value::Tuple(a), Value::Tuple(b)) => a == b,
+            (Value::Array(a), Value::Array(b)) => a == b,
+            (Value::Struct(a), Value::Struct(b)) => a == b,
+            (Value::FunctionPointer(a), Value::FunctionPointer(b)) => a == b,
+            (Value::Pointer(a, _), Value::Pointer(b, _)) => a == b,
+            (Value::LValue(a), Value::LValue(b)) => a == b,
+            _ => false,
+        }
+    }
+}
+
+impl Eq for Value<'_> {}
+impl Hash for Value<'_> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            Value::Void => state.write_u8(0),
+            Value::Uninitialized => state.write_u8(1),
+            Value::Bool(a) => {
+                state.write_u8(2);
+                state.write_u8(*a as u8);
+            }
+            Value::U8(a) => {
+                state.write_u8(3);
+                state.write_u8(*a);
+            }
+            Value::U16(a) => {
+                state.write_u8(4);
+                state.write_u16(*a);
+            }
+            Value::U32(a) => {
+                state.write_u8(5);
+                state.write_u32(*a);
+            }
+            Value::U64(a) => {
+                state.write_u8(6);
+                state.write_u64(*a);
+            }
+            Value::U128(a) => {
+                state.write_u8(7);
+                state.write_u128(*a);
+            }
+            Value::I8(a) => {
+                state.write_u8(8);
+                state.write_u8(*a as u8);
+            }
+            Value::I16(a) => {
+                state.write_u8(9);
+                state.write_u16(*a as u16);
+            }
+            Value::I32(a) => {
+                state.write_u8(10);
+                state.write_u32(*a as u32);
+            }
+            Value::I64(a) => {
+                state.write_u8(11);
+                state.write_u64(*a as u64);
+            }
+            Value::I128(a) => {
+                state.write_u8(12);
+                state.write_u128(*a as u128);
+            }
+            Value::USize(a) => {
+                state.write_u8(13);
+                state.write_usize(*a);
+            }
+            Value::ISize(a) => {
+                state.write_u8(14);
+                state.write_usize(*a as usize);
+            }
+            Value::F32(a) => {
+                state.write_u8(15);
+                state.write_u32(a.to_bits());
+            }
+            Value::F64(a) => {
+                state.write_u8(16);
+                state.write_u64(a.to_bits());
+            }
+            Value::Bytes(a, a_len) => {
+                state.write_u8(17);
+                a.hash(state);
+                a_len.hash(state);
+            }
+            Value::Tuple(a) => {
+                state.write_u8(18);
+                a.hash(state);
+            }
+            Value::Array(a) => {
+                state.write_u8(19);
+                a.hash(state);
+            }
+            Value::Struct(a) => {
+                state.write_u8(20);
+                a.hash(state);
+            }
+            Value::FunctionPointer(a) => {
+                state.write_u8(21);
+                a.hash(state);
+            }
+            Value::Pointer(a, ty) => {
+                state.write_u8(22);
+                a.hash(state);
+                ty.hash(state);
+            }
+            Value::LValue(a) => {
+                state.write_u8(23);
+                a.hash(state);
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -66,8 +200,12 @@ pub enum ConstEvalErrorKind {
     CompilerBug(ByRef<Backtrace>),
     #[error("cyclic reference")]
     CyclicReference,
+    #[error("performing pointer operations on pointers of different provenance")]
+    ProvenanceMismatch,
     #[error("trying to access uninitialized value")]
     Uninitialized,
+    #[error("accessing memory location via an incompatible pointer")]
+    IncompatiblePointer,
     #[error("index out of bounds")]
     IndexOutOfBounds,
     #[error("arithmetic overflow")]
@@ -86,6 +224,8 @@ pub enum ConstEvalErrorKind {
     UseAfterFree,
     #[error("invalid pointer used to free memory")]
     InvalidFree,
+    #[error("function call with an wrong signature")]
+    InvalidCall,
 
     // These are not errors, but they are used to signal that the evaluation should stop.
     // They are bugs if they leak to the caller
@@ -95,9 +235,9 @@ pub enum ConstEvalErrorKind {
     Return,
 }
 
-impl From<ConstEvalErrorKind> for CodeErrorKind {
+impl From<ConstEvalErrorKind> for CodeDiagnostic {
     fn from(kind: ConstEvalErrorKind) -> Self {
-        CodeErrorKind::CannotConstEvaluate(kind)
+        CodeDiagnostic::CannotConstEvaluate(kind)
     }
 }
 
@@ -140,7 +280,7 @@ use super::builder::TypeBuilder;
 use super::IRItemP;
 
 impl<'ir> Value<'ir> {
-    fn equal(self, other: Value) -> Result<Value<'ir>, ConstEvalErrorKind> {
+    fn equals(self, other: Value<'ir>) -> Result<Value<'ir>, ConstEvalErrorKind> {
         match (self, other) {
             (Value::Bool(a), Value::Bool(b)) => Ok(Value::Bool(a == b)),
             (Value::U8(a), Value::U8(b)) => Ok(Value::Bool(a == b)),
@@ -153,27 +293,82 @@ impl<'ir> Value<'ir> {
             (Value::I32(a), Value::I32(b)) => Ok(Value::Bool(a == b)),
             (Value::I64(a), Value::I64(b)) => Ok(Value::Bool(a == b)),
             (Value::I128(a), Value::I128(b)) => Ok(Value::Bool(a == b)),
+            (Value::F32(a), Value::F32(b)) => Ok(Value::Bool(a == b)),
+            (Value::F64(a), Value::F64(b)) => Ok(Value::Bool(a == b)),
             (Value::USize(a), Value::USize(b)) => Ok(Value::Bool(a == b)),
             (Value::ISize(a), Value::ISize(b)) => Ok(Value::Bool(a == b)),
+            (Value::Bytes(a_slice, a_index), Value::Bytes(b_slice, b_index)) => {
+                Ok(Value::Bool(a_slice == b_slice && a_index == b_index))
+            }
+            (Value::FunctionPointer(a), Value::FunctionPointer(b)) => Ok(Value::Bool(a == b)),
+            (Value::Pointer(a, _), Value::Pointer(b, _)) => Ok(Value::Bool(a == b)),
             _ => Err(ConstEvalErrorKind::Unsupported),
         }
     }
 
-    fn cmp(self, other: Value) -> Result<Ordering, ConstEvalErrorKind> {
+    fn compare(self, other: Value<'ir>) -> Result<Option<Ordering>, ConstEvalErrorKind> {
         match (self, other) {
-            (Value::U8(a), Value::U8(b)) => Ok(a.cmp(&b)),
-            (Value::U16(a), Value::U16(b)) => Ok(a.cmp(&b)),
-            (Value::U32(a), Value::U32(b)) => Ok(a.cmp(&b)),
-            (Value::U64(a), Value::U64(b)) => Ok(a.cmp(&b)),
-            (Value::U128(a), Value::U128(b)) => Ok(a.cmp(&b)),
-            (Value::I8(a), Value::I8(b)) => Ok(a.cmp(&b)),
-            (Value::I16(a), Value::I16(b)) => Ok(a.cmp(&b)),
-            (Value::I32(a), Value::I32(b)) => Ok(a.cmp(&b)),
-            (Value::I64(a), Value::I64(b)) => Ok(a.cmp(&b)),
-            (Value::I128(a), Value::I128(b)) => Ok(a.cmp(&b)),
-            (Value::USize(a), Value::USize(b)) => Ok(a.cmp(&b)),
-            (Value::ISize(a), Value::ISize(b)) => Ok(a.cmp(&b)),
-            (Value::Bool(a), Value::Bool(b)) => Ok(a.cmp(&b)),
+            (Value::U8(a), Value::U8(b)) => Ok(a.partial_cmp(&b)),
+            (Value::U16(a), Value::U16(b)) => Ok(a.partial_cmp(&b)),
+            (Value::U32(a), Value::U32(b)) => Ok(a.partial_cmp(&b)),
+            (Value::U64(a), Value::U64(b)) => Ok(a.partial_cmp(&b)),
+            (Value::U128(a), Value::U128(b)) => Ok(a.partial_cmp(&b)),
+            (Value::I8(a), Value::I8(b)) => Ok(a.partial_cmp(&b)),
+            (Value::I16(a), Value::I16(b)) => Ok(a.partial_cmp(&b)),
+            (Value::I32(a), Value::I32(b)) => Ok(a.partial_cmp(&b)),
+            (Value::I64(a), Value::I64(b)) => Ok(a.partial_cmp(&b)),
+            (Value::I128(a), Value::I128(b)) => Ok(a.partial_cmp(&b)),
+            (Value::F32(a), Value::F32(b)) => Ok(a.partial_cmp(&b)),
+            (Value::F64(a), Value::F64(b)) => Ok(a.partial_cmp(&b)),
+            (Value::USize(a), Value::USize(b)) => Ok(a.partial_cmp(&b)),
+            (Value::ISize(a), Value::ISize(b)) => Ok(a.partial_cmp(&b)),
+            (Value::Bool(a), Value::Bool(b)) => Ok(a.partial_cmp(&b)),
+            (Value::Bytes(a_slice, a_index), Value::Bytes(b_slice, b_index)) => {
+                if a_slice == b_slice {
+                    Ok(a_index.partial_cmp(&b_index))
+                } else {
+                    Err(ConstEvalErrorKind::ProvenanceMismatch)
+                }
+            }
+            (Value::Pointer(a, _), Value::Pointer(b, _)) => match (a, b) {
+                (LValue::Const(a), LValue::Const(b)) => {
+                    if a == b {
+                        Ok(Some(Ordering::Equal))
+                    } else {
+                        Err(ConstEvalErrorKind::ProvenanceMismatch)
+                    }
+                }
+                (LValue::Variable(a), LValue::Variable(b))
+                | (LValue::Alloc(a), LValue::Alloc(b)) => {
+                    if a == b {
+                        Ok(Some(Ordering::Equal))
+                    } else {
+                        Err(ConstEvalErrorKind::ProvenanceMismatch)
+                    }
+                }
+                (LValue::Field(a, a_id), LValue::Field(b, b_id)) => {
+                    if a == b && a_id == b_id {
+                        Ok(Some(Ordering::Equal))
+                    } else {
+                        Err(ConstEvalErrorKind::ProvenanceMismatch)
+                    }
+                }
+                (LValue::TupleIndex(a, a_idx), LValue::TupleIndex(b, b_idx)) => {
+                    if a == b && a_idx == b_idx {
+                        Ok(Some(Ordering::Equal))
+                    } else {
+                        Err(ConstEvalErrorKind::ProvenanceMismatch)
+                    }
+                }
+                (LValue::Index(a, a_idx), LValue::Index(b, b_idx)) => {
+                    if a == b {
+                        Ok(a_idx.partial_cmp(&b_idx))
+                    } else {
+                        Err(ConstEvalErrorKind::ProvenanceMismatch)
+                    }
+                }
+                _ => Err(ConstEvalErrorKind::Unsupported),
+            },
             _ => Err(ConstEvalErrorKind::Unsupported),
         }
     }
@@ -217,6 +412,8 @@ impl<'ir> Add for Value<'ir> {
                 .checked_add(b)
                 .map(ISize)
                 .ok_or(ConstEvalErrorKind::ArithmeticOverflow),
+            (F32(a), F32(b)) => Ok(F32(a + b)),
+            (F64(a), F64(b)) => Ok(F64(a + b)),
             _ => Err(ConstEvalErrorKind::Unsupported),
         }
     }
@@ -260,6 +457,8 @@ impl<'ir> Sub for Value<'ir> {
                 .checked_sub(b)
                 .map(ISize)
                 .ok_or(ConstEvalErrorKind::ArithmeticOverflow),
+            (F32(a), F32(b)) => Ok(F32(a - b)),
+            (F64(a), F64(b)) => Ok(F64(a - b)),
             _ => Err(ConstEvalErrorKind::Unsupported),
         }
     }
@@ -303,6 +502,8 @@ impl<'ir> Mul for Value<'ir> {
                 .checked_mul(b)
                 .map(ISize)
                 .ok_or(ConstEvalErrorKind::ArithmeticOverflow),
+            (F32(a), F32(b)) => Ok(F32(a * b)),
+            (F64(a), F64(b)) => Ok(F64(a * b)),
             _ => Err(ConstEvalErrorKind::Unsupported),
         }
     }
@@ -519,6 +720,8 @@ impl<'ir> Div for Value<'ir> {
             (I128(a), I128(b)) => a.checked_div(b).map(I128),
             (USize(a), USize(b)) => a.checked_div(b).map(USize),
             (ISize(a), ISize(b)) => a.checked_div(b).map(ISize),
+            (F32(a), F32(b)) => Some(F32(a / b)),
+            (F64(a), F64(b)) => Some(F64(a / b)),
             _ => None,
         };
 
@@ -558,6 +761,7 @@ struct ConstEvalCtxInner<'ir> {
 
 #[derive(Clone)]
 pub struct ConstEvalCtx<'ir> {
+    global_ctx: GlobalCtx,
     ir: &'ir IrCtx<'ir>,
     malloc_bag: MallocBag<'ir>,
     inner: Rc<RefCell<ConstEvalCtxInner<'ir>>>,
@@ -603,8 +807,9 @@ impl<'ir> MallocBag<'ir> {
 }
 
 impl<'ir> ConstEvalCtx<'ir> {
-    pub fn new(ir: &'ir IrCtx<'ir>, malloc_bag: MallocBag<'ir>) -> Self {
+    pub fn new(global_ctx: GlobalCtx, ir: &'ir IrCtx<'ir>, malloc_bag: MallocBag<'ir>) -> Self {
         Self {
+            global_ctx,
             ir,
             malloc_bag,
             inner: Rc::new(RefCell::new(ConstEvalCtxInner {
@@ -661,6 +866,7 @@ pub struct ConstEvaluator<'ir> {
 
 impl<'ir> ConstEvaluator<'ir> {
     pub fn new<I>(
+        global_ctx: GlobalCtx,
         diag: DiagnosticsStack,
         malloc_bag: MallocBag<'ir>,
         ir: &'ir IrCtx<'ir>,
@@ -669,7 +875,7 @@ impl<'ir> ConstEvaluator<'ir> {
     where
         I: IntoIterator<Item = (IrId, TyP<'ir>)>,
     {
-        let ctx = ConstEvalCtx::new(ir, malloc_bag);
+        let ctx = ConstEvalCtx::new(global_ctx, ir, malloc_bag);
         for (id, typ) in local_types {
             ctx.declare(id, typ);
         }
@@ -687,6 +893,7 @@ impl<'ir> ConstEvaluator<'ir> {
     }
 
     pub fn for_codegen<I>(
+        global_ctx: GlobalCtx,
         diag: DiagnosticsStack,
         malloc_bag: MallocBag<'ir>,
         ir: &'ir IrCtx<'ir>,
@@ -695,7 +902,7 @@ impl<'ir> ConstEvaluator<'ir> {
     where
         I: IntoIterator<Item = (IrId, TyP<'ir>)>,
     {
-        let mut ret = Self::new(diag, malloc_bag, ir, local_types);
+        let mut ret = Self::new(global_ctx, diag, malloc_bag, ir, local_types);
         ret.codegen = true;
         ret
     }
@@ -738,7 +945,6 @@ impl<'ir> ConstEvaluator<'ir> {
             Value::U16(a) => Value::U128(a as u128),
             Value::U32(a) => Value::U128(a as u128),
             Value::U64(a) => Value::U128(a as u128),
-            Value::U128(a) => Value::U128(a),
             Value::USize(a) => Value::U128(a as u128),
             Value::I8(a) => Value::I128(a as i128),
             Value::I16(a) => Value::I128(a as i128),
@@ -747,6 +953,7 @@ impl<'ir> ConstEvaluator<'ir> {
             Value::I128(a) => Value::I128(a),
             Value::ISize(a) => Value::I128(a as i128),
             Value::Bool(a) => Value::U128(a as u128),
+            Value::F32(a) => Value::F64(a as f64),
             _ => val,
         };
 
@@ -763,6 +970,9 @@ impl<'ir> ConstEvaluator<'ir> {
             (Value::U128(a), Ty::Builtin(BuiltinType::I64)) => Ok(Value::I64(a as i64)),
             (Value::U128(a), Ty::Builtin(BuiltinType::I128)) => Ok(Value::I128(a as i128)),
             (Value::U128(a), Ty::Builtin(BuiltinType::ISize)) => Ok(Value::ISize(a as isize)),
+            (Value::U128(a), Ty::Builtin(BuiltinType::F64)) => Ok(Value::F64(a as f64)),
+            (Value::U128(a), Ty::Builtin(BuiltinType::F32)) => Ok(Value::F32(a as f32)),
+
             (Value::I128(a), Ty::Builtin(BuiltinType::U8)) => Ok(Value::U8(a as u8)),
             (Value::I128(a), Ty::Builtin(BuiltinType::U16)) => Ok(Value::U16(a as u16)),
             (Value::I128(a), Ty::Builtin(BuiltinType::U32)) => Ok(Value::U32(a as u32)),
@@ -775,11 +985,27 @@ impl<'ir> ConstEvaluator<'ir> {
             (Value::I128(a), Ty::Builtin(BuiltinType::I64)) => Ok(Value::I64(a as i64)),
             (Value::I128(a), Ty::Builtin(BuiltinType::I128)) => Ok(Value::I128(a)),
             (Value::I128(a), Ty::Builtin(BuiltinType::ISize)) => Ok(Value::ISize(a as isize)),
-            (Value::F64(a), Ty::Builtin(BuiltinType::F32)) => Ok(Value::F32(a)),
-            (Value::F32(a), Ty::Builtin(BuiltinType::F64)) => Ok(Value::F64(a)),
+            (Value::I128(a), Ty::Builtin(BuiltinType::F64)) => Ok(Value::F64(a as f64)),
+            (Value::I128(a), Ty::Builtin(BuiltinType::F32)) => Ok(Value::F32(a as f32)),
+
+            (Value::F64(a), Ty::Builtin(BuiltinType::U8)) => Ok(Value::U8(a as u8)),
+            (Value::F64(a), Ty::Builtin(BuiltinType::U16)) => Ok(Value::U16(a as u16)),
+            (Value::F64(a), Ty::Builtin(BuiltinType::U32)) => Ok(Value::U32(a as u32)),
+            (Value::F64(a), Ty::Builtin(BuiltinType::U64)) => Ok(Value::U64(a as u64)),
+            (Value::F64(a), Ty::Builtin(BuiltinType::U128)) => Ok(Value::U128(a as u128)),
+            (Value::F64(a), Ty::Builtin(BuiltinType::USize)) => Ok(Value::USize(a as usize)),
+            (Value::F64(a), Ty::Builtin(BuiltinType::I8)) => Ok(Value::I8(a as i8)),
+            (Value::F64(a), Ty::Builtin(BuiltinType::I16)) => Ok(Value::I16(a as i16)),
+            (Value::F64(a), Ty::Builtin(BuiltinType::I32)) => Ok(Value::I32(a as i32)),
+            (Value::F64(a), Ty::Builtin(BuiltinType::I64)) => Ok(Value::I64(a as i64)),
+            (Value::F64(a), Ty::Builtin(BuiltinType::I128)) => Ok(Value::I128(a as i128)),
+            (Value::F64(a), Ty::Builtin(BuiltinType::ISize)) => Ok(Value::ISize(a as isize)),
+
+            (Value::F64(a), Ty::Builtin(BuiltinType::F32)) => Ok(Value::F32(a as f32)),
+
             (Value::FunctionPointer(id), Ty::FunctionPointer(..)) => Ok(Value::FunctionPointer(id)),
-            (Value::Pointer(value), Ty::Pointer(_underlying, _is_const)) => {
-                Ok(Value::Pointer(value))
+            (Value::Pointer(value, original_typ), Ty::Pointer(_, _)) => {
+                Ok(Value::Pointer(value, original_typ))
             }
             _ => unsupported!(self),
         }
@@ -856,7 +1082,7 @@ impl<'ir> ConstEvaluator<'ir> {
                         Ok(_) => {}
                         Err(e) => {
                             let AluminaError::CodeErrors(ref v) = e else { return Err(e); };
-                            let [CodeError { kind: CodeErrorKind::CannotConstEvaluate(ConstEvalErrorKind::Jump(label)), .. }] = v[..] else { return Err(e) };
+                            let [CodeError { kind: CodeDiagnostic::CannotConstEvaluate(ConstEvalErrorKind::Jump(label)), .. }] = v[..] else { return Err(e) };
 
                             if let Some(new_ip) = label_indexes.get(&label) {
                                 ip = *new_ip;
@@ -997,8 +1223,8 @@ impl<'ir> ConstEvaluator<'ir> {
 
         match &expr.kind {
             ExprKind::Void => Ok(Value::Void),
-            ExprKind::Binary(op, lhs, rhs) => {
-                let lhs = self.const_eval_rvalue(lhs)?;
+            ExprKind::Binary(op, lhs_e, rhs_e) => {
+                let lhs = self.const_eval_rvalue(lhs_e)?;
 
                 // Special case for short-circuiting operators
                 match (op, lhs) {
@@ -1006,12 +1232,12 @@ impl<'ir> ConstEvaluator<'ir> {
                         return if a {
                             Ok(lhs)
                         } else {
-                            self.const_eval_rvalue(rhs)
+                            self.const_eval_rvalue(rhs_e)
                         }
                     }
                     (BinOp::And, Value::Bool(a)) => {
                         return if a {
-                            self.const_eval_rvalue(rhs)
+                            self.const_eval_rvalue(rhs_e)
                         } else {
                             Ok(lhs)
                         }
@@ -1022,8 +1248,8 @@ impl<'ir> ConstEvaluator<'ir> {
                     _ => {}
                 };
 
-                let rhs = self.const_eval_rvalue(rhs)?;
-                self.bin_op(lhs, *op, rhs)
+                let rhs = self.const_eval_rvalue(rhs_e)?;
+                self.bin_op(lhs, lhs_e.ty, *op, rhs, rhs_e.ty)
             }
             ExprKind::Local(id) => Ok(Value::LValue(LValue::Variable(
                 *self.remapped_variables.get(id).unwrap_or(id),
@@ -1039,18 +1265,21 @@ impl<'ir> ConstEvaluator<'ir> {
 
                 ret.with_backtrace(&self.diag)
             }
-            ExprKind::Ref(value) => {
-                let value = self.const_eval_defered(value)?;
-                match value {
-                    Value::LValue(lvalue) => Ok(Value::Pointer(lvalue)),
-                    _ => unsupported!(self),
-                }
-            }
+            ExprKind::Ref(value) => match self.const_eval_defered(value)? {
+                Value::LValue(lvalue) => Ok(Value::Pointer(lvalue, value.ty)),
+                _ => unsupported!(self),
+            },
             ExprKind::Deref(value) => {
                 let value = self.const_eval_rvalue(value)?;
                 match value {
-                    Value::Pointer(lvalue) => Ok(Value::LValue(lvalue)),
-                    Value::Str(arr, off) => {
+                    Value::Pointer(lvalue, original_typ) => {
+                        if expr.ty != original_typ {
+                            Err(ConstEvalErrorKind::IncompatiblePointer).with_backtrace(&self.diag)
+                        } else {
+                            Ok(Value::LValue(lvalue))
+                        }
+                    }
+                    Value::Bytes(arr, off) => {
                         if off >= arr.len() {
                             return Err(ConstEvalErrorKind::IndexOutOfBounds)
                                 .with_backtrace(&self.diag);
@@ -1135,13 +1364,13 @@ impl<'ir> ConstEvaluator<'ir> {
                     _ => bug!(self),
                 }
             }
-            ExprKind::AssignOp(op, lhs, rhs) => {
-                let lhs = self.const_eval_defered(lhs)?;
-                let rhs = self.const_eval_rvalue(rhs)?;
+            ExprKind::AssignOp(op, lhs_e, rhs_e) => {
+                let lhs = self.const_eval_defered(lhs_e)?;
+                let rhs = self.const_eval_rvalue(rhs_e)?;
                 match lhs {
                     Value::LValue(lvalue) => {
                         let normalized = self.materialize(lhs)?;
-                        let res = self.bin_op(normalized, *op, rhs)?;
+                        let res = self.bin_op(normalized, lhs_e.ty, *op, rhs, rhs_e.ty)?;
                         self.assign(lvalue, res)?;
                         Ok(Value::Void)
                     }
@@ -1156,15 +1385,72 @@ impl<'ir> ConstEvaluator<'ir> {
                 IntrinsicValueKind::Uninitialized => Ok(Value::Uninitialized),
                 IntrinsicValueKind::Dangling(..) => Ok(Value::Uninitialized),
                 IntrinsicValueKind::SizeOfLike(_, _) => unsupported!(self),
+                IntrinsicValueKind::Transmute(inner) => {
+                    let inner = self.const_eval_rvalue(inner)?;
+
+                    // Very limited transmutations
+                    match (inner, expr.ty) {
+                        (Value::U8(a), Ty::Builtin(BuiltinType::I8)) => Ok(Value::I8(a as i8)),
+                        (Value::U16(a), Ty::Builtin(BuiltinType::I16)) => Ok(Value::I16(a as i16)),
+                        (Value::U32(a), Ty::Builtin(BuiltinType::I32)) => Ok(Value::I32(a as i32)),
+                        (Value::U64(a), Ty::Builtin(BuiltinType::I64)) => Ok(Value::I64(a as i64)),
+                        (Value::U128(a), Ty::Builtin(BuiltinType::I128)) => {
+                            Ok(Value::I128(a as i128))
+                        }
+                        (Value::USize(a), Ty::Builtin(BuiltinType::ISize)) => {
+                            Ok(Value::ISize(a as isize))
+                        }
+
+                        (Value::I8(a), Ty::Builtin(BuiltinType::U8)) => Ok(Value::U8(a as u8)),
+                        (Value::I16(a), Ty::Builtin(BuiltinType::U16)) => Ok(Value::U16(a as u16)),
+                        (Value::I32(a), Ty::Builtin(BuiltinType::U32)) => Ok(Value::U32(a as u32)),
+                        (Value::I64(a), Ty::Builtin(BuiltinType::U64)) => Ok(Value::U64(a as u64)),
+                        (Value::I128(a), Ty::Builtin(BuiltinType::U128)) => {
+                            Ok(Value::U128(a as u128))
+                        }
+                        (Value::ISize(a), Ty::Builtin(BuiltinType::USize)) => {
+                            Ok(Value::USize(a as usize))
+                        }
+
+                        (Value::F64(a), Ty::Builtin(BuiltinType::U64)) => {
+                            Ok(Value::U64(a.to_bits()))
+                        }
+                        (Value::F64(a), Ty::Builtin(BuiltinType::I64)) => {
+                            Ok(Value::I64(a.to_bits() as i64))
+                        }
+                        (Value::F32(a), Ty::Builtin(BuiltinType::U32)) => {
+                            Ok(Value::U32(a.to_bits()))
+                        }
+                        (Value::F32(a), Ty::Builtin(BuiltinType::I32)) => {
+                            Ok(Value::I32(a.to_bits() as i32))
+                        }
+
+                        (Value::U64(a), Ty::Builtin(BuiltinType::F64)) => {
+                            Ok(Value::F64(f64::from_bits(a)))
+                        }
+                        (Value::I64(a), Ty::Builtin(BuiltinType::F64)) => {
+                            Ok(Value::F64(f64::from_bits(a as u64)))
+                        }
+                        (Value::U32(a), Ty::Builtin(BuiltinType::F32)) => {
+                            Ok(Value::F32(f32::from_bits(a)))
+                        }
+                        (Value::I32(a), Ty::Builtin(BuiltinType::F32)) => {
+                            Ok(Value::F32(f32::from_bits(a as u32)))
+                        }
+                        _ => unsupported!(self),
+                    }
+                }
                 IntrinsicValueKind::Asm(_) => unsupported!(self),
                 IntrinsicValueKind::FunctionLike(_) => unsupported!(self),
                 IntrinsicValueKind::ConstLike(_) => unsupported!(self),
-                IntrinsicValueKind::InConstContext => Ok(Value::Bool(!self.codegen)),
+                IntrinsicValueKind::InConstContext => Ok(Value::Bool(
+                    !self.codegen || self.ctx.global_ctx.has_option("force-const-context"),
+                )),
                 IntrinsicValueKind::ConstPanic(expr) => {
                     let value = self.const_eval_rvalue(expr)?;
                     match self.extract_constant_string_from_slice(&value) {
                         Some(msg) => {
-                            return Err(CodeErrorKind::ConstPanic(
+                            return Err(CodeDiagnostic::ConstPanic(
                                 std::str::from_utf8(msg).unwrap().to_string(),
                             ))
                             .with_backtrace(&self.diag)
@@ -1179,11 +1465,11 @@ impl<'ir> ConstEvaluator<'ir> {
                     match self.extract_constant_string_from_slice(&value) {
                         Some(msg) => {
                             if *is_warning {
-                                self.diag.warn(CodeErrorKind::ConstMessage(
+                                self.diag.warn(CodeDiagnostic::ConstMessage(
                                     std::str::from_utf8(msg).unwrap().to_string(),
                                 ));
                             } else {
-                                self.diag.note(CodeErrorKind::ConstMessage(
+                                self.diag.note(CodeDiagnostic::ConstMessage(
                                     std::str::from_utf8(msg).unwrap().to_string(),
                                 ));
                             }
@@ -1202,10 +1488,10 @@ impl<'ir> ConstEvaluator<'ir> {
                             let value = make_uninitialized(self.ir, self.types.array(ty, size));
                             self.ctx.malloc_bag.define(id, value);
 
-                            Ok(Value::Pointer(LValue::Index(
-                                LValue::Alloc(id).alloc_on(self.ir),
-                                0,
-                            )))
+                            Ok(Value::Pointer(
+                                LValue::Index(LValue::Alloc(id).alloc_on(self.ir), 0),
+                                ty,
+                            ))
                         }
                         _ => bug!(self),
                     }
@@ -1213,7 +1499,8 @@ impl<'ir> ConstEvaluator<'ir> {
                 IntrinsicValueKind::ConstFree(ptr) => {
                     let ptr = self.const_eval_rvalue(ptr)?;
                     match ptr {
-                        Value::Pointer(LValue::Index(LValue::Alloc(id), 0))
+                        // don't need to check that it's a compatible pointer here really
+                        Value::Pointer(LValue::Index(LValue::Alloc(id), 0), _)
                             if self.ctx.malloc_bag.free(*id).is_some() =>
                         {
                             Ok(Value::Void)
@@ -1230,14 +1517,12 @@ impl<'ir> ConstEvaluator<'ir> {
             }
             ExprKind::Call(callee, args) => {
                 let callee = self.const_eval_rvalue(callee)?;
-                let (arg_spec, expr, local_defs) = match callee {
+                let (arg_spec, func_body, ret) = match callee {
                     Value::FunctionPointer(fun) => {
                         let func = fun.get_function().with_backtrace(&self.diag)?;
-
-                        let (body, local_defs) = func
+                        let func_body = func
                             .body
                             .get()
-                            .and_then(|b| b.raw_body.map(|rb| (rb, b.local_defs)))
                             .ok_or_else(|| {
                                 ConstEvalErrorKind::UnsupportedFunction(
                                     func.name.unwrap_or("<unnamed>").to_string(),
@@ -1245,20 +1530,36 @@ impl<'ir> ConstEvaluator<'ir> {
                             })
                             .with_backtrace(&self.diag)?;
 
-                        (func.args, body, local_defs)
+                        (func.args, func_body, func.return_type)
                     }
                     _ => unsupported!(self),
                 };
 
                 let mut remapped_variables = HashMap::default();
-                for local_def in local_defs {
+                for local_def in func_body.local_defs {
                     let new_id = self.ir.make_id();
                     remapped_variables.insert(local_def.id, new_id);
 
                     self.ctx.declare(new_id, local_def.typ);
                 }
 
+                // To avoid function pointer casting shenanigans, we check that the signature matches the
+                // actual call. Mono does not help us here, because function pointer punning is perfectly valid.
+                // We could disallow function pointer casting in const-eval, but that would make dyn pointers
+                // unusable.
+                if !expr.ty.assignable_from(ret) {
+                    return Err(ConstEvalErrorKind::InvalidCall).with_backtrace(&self.diag);
+                }
+
+                if args.len() != arg_spec.len() {
+                    return Err(ConstEvalErrorKind::InvalidCall).with_backtrace(&self.diag);
+                }
+
                 for (arg, arg_spec) in args.iter().zip(arg_spec) {
+                    if !arg_spec.ty.assignable_from(arg.ty) {
+                        return Err(ConstEvalErrorKind::InvalidCall).with_backtrace(&self.diag);
+                    }
+
                     let arg = self.const_eval_rvalue(arg)?;
                     let new_id = self.ir.make_id();
                     remapped_variables.insert(arg_spec.id, new_id);
@@ -1268,13 +1569,13 @@ impl<'ir> ConstEvaluator<'ir> {
 
                 let mut child = self.make_child(remapped_variables)?;
 
-                let ret = match child.const_eval_rvalue(expr) {
+                let ret = match child.const_eval_rvalue(func_body.expr) {
                     Ok(value) => Ok(value),
                     Err(e) => {
                         let AluminaError::CodeErrors(ref v) = e else {
                             return Err(e);
                         };
-                        let [CodeError { kind: CodeErrorKind::CannotConstEvaluate(ConstEvalErrorKind::Return), .. }] = v[..] else { return Err(e) };
+                        let [CodeError { kind: CodeDiagnostic::CannotConstEvaluate(ConstEvalErrorKind::Return), .. }] = v[..] else { return Err(e) };
                         let value = child.return_slot.take().unwrap();
                         Ok(value)
                     }
@@ -1286,6 +1587,16 @@ impl<'ir> ConstEvaluator<'ir> {
             ExprKind::Unreachable => {
                 Err(ConstEvalErrorKind::ToReachTheUnreachableStar).with_backtrace(&self.diag)
             }
+            ExprKind::Tag(tag, inner) => match *tag {
+                "non_const" => {
+                    if self.codegen {
+                        self.const_eval_rvalue(inner)
+                    } else {
+                        unsupported!(self)
+                    }
+                }
+                _ => self.const_eval_rvalue(inner),
+            },
         }
     }
 
@@ -1293,8 +1604,10 @@ impl<'ir> ConstEvaluator<'ir> {
     fn plus_minus(
         &mut self,
         lhs: Value<'ir>,
+        lhs_typ: TyP<'ir>,
         op: BinOp,
         rhs: Value<'ir>,
+        rhs_typ: TyP<'ir>,
     ) -> Result<Value<'ir>, AluminaError> {
         macro_rules! offset {
             () => {
@@ -1307,44 +1620,80 @@ impl<'ir> ConstEvaluator<'ir> {
             };
         }
 
+        macro_rules! check_type_match {
+            ($original:expr, $current:expr) => {{
+                let Ty::Pointer(current, _) = $current else { bug!(self); };
+
+                if $original != *current {
+                    return Err(ConstEvalErrorKind::IncompatiblePointer).with_backtrace(&self.diag);
+                }
+            }};
+        }
+
         match (lhs, rhs) {
             (
-                Value::Pointer(LValue::Index(a, a_offset)),
-                Value::Pointer(LValue::Index(b, b_offset)),
+                Value::Pointer(LValue::Index(a, a_offset), a_orig),
+                Value::Pointer(LValue::Index(b, b_offset), b_orig),
             ) if op == BinOp::Minus => {
                 if b != a {
-                    return Err(ConstEvalErrorKind::IndexOutOfBounds).with_backtrace(&self.diag);
+                    return Err(ConstEvalErrorKind::ProvenanceMismatch).with_backtrace(&self.diag);
+                }
+
+                check_type_match!(a_orig, lhs_typ);
+                check_type_match!(b_orig, rhs_typ);
+
+                let diff = (a_offset as isize) - (b_offset as isize);
+                return Ok(Value::ISize(diff));
+            }
+            (Value::Bytes(a, a_offset), Value::Bytes(b, b_offset)) if op == BinOp::Minus => {
+                if b != a {
+                    return Err(ConstEvalErrorKind::ProvenanceMismatch).with_backtrace(&self.diag);
                 }
 
                 let diff = (a_offset as isize) - (b_offset as isize);
                 return Ok(Value::ISize(diff));
             }
-            (Value::Str(buf, offset), _) => {
+            (Value::Pointer(a, a_orig), Value::Pointer(b, b_orig)) if op == BinOp::Minus => {
+                if a == b {
+                    check_type_match!(a_orig, lhs_typ);
+                    check_type_match!(b_orig, rhs_typ);
+
+                    return Ok(Value::ISize(0));
+                } else {
+                    return Err(ConstEvalErrorKind::ProvenanceMismatch).with_backtrace(&self.diag);
+                }
+            }
+            (Value::Bytes(buf, offset), _) => {
                 let new_offset = match op {
                     BinOp::Plus => (offset as isize) + offset!(),
-                    BinOp::Minus => (offset as isize) + offset!(),
+                    BinOp::Minus => (offset as isize) - offset!(),
                     _ => bug!(self),
                 };
                 if new_offset < 0 || new_offset > (buf.len() as isize) {
                     return Err(ConstEvalErrorKind::IndexOutOfBounds).with_backtrace(&self.diag);
                 }
-                return Ok(Value::Str(buf, new_offset as usize));
+                return Ok(Value::Bytes(buf, new_offset as usize));
             }
-            (Value::Pointer(LValue::Index(inner, offset)), _) => {
+            (Value::Pointer(LValue::Index(inner, offset), orig), _) => {
                 let arr = match self.materialize_lvalue(*inner)? {
                     Value::Array(arr) => arr,
                     _ => unsupported!(self),
                 };
 
+                check_type_match!(orig, lhs_typ);
+
                 let new_offset = match op {
                     BinOp::Plus => (offset as isize) + offset!(),
-                    BinOp::Minus => (offset as isize) + offset!(),
+                    BinOp::Minus => (offset as isize) - offset!(),
                     _ => bug!(self),
                 };
                 if new_offset < 0 || new_offset > (arr.len() as isize) {
                     return Err(ConstEvalErrorKind::IndexOutOfBounds).with_backtrace(&self.diag);
                 }
-                return Ok(Value::Pointer(LValue::Index(inner, new_offset as usize)));
+                return Ok(Value::Pointer(
+                    LValue::Index(inner, new_offset as usize),
+                    orig,
+                ));
             }
 
             _ => {}
@@ -1362,8 +1711,10 @@ impl<'ir> ConstEvaluator<'ir> {
     fn bin_op(
         &mut self,
         lhs: Value<'ir>,
+        lhs_typ: TyP<'ir>,
         op: BinOp,
         rhs: Value<'ir>,
+        rhs_typ: TyP<'ir>,
     ) -> Result<Value<'ir>, AluminaError> {
         let ret = match op {
             BinOp::BitAnd => lhs & rhs,
@@ -1371,30 +1722,30 @@ impl<'ir> ConstEvaluator<'ir> {
             BinOp::BitXor => lhs ^ rhs,
             BinOp::Or => lhs | rhs,
             BinOp::And => lhs & rhs,
-            BinOp::Eq => lhs.equal(rhs),
-            BinOp::Neq => lhs.equal(rhs).and_then(|v| !v),
+            BinOp::Eq => lhs.equals(rhs),
+            BinOp::Neq => lhs.equals(rhs).and_then(|v| !v),
             BinOp::Lt => Ok(Value::Bool(matches!(
-                lhs.cmp(rhs).with_backtrace(&self.diag)?,
-                Ordering::Less
+                lhs.compare(rhs).with_backtrace(&self.diag)?,
+                Some(Ordering::Less)
             ))),
             BinOp::LEq => Ok(Value::Bool(matches!(
-                lhs.cmp(rhs).with_backtrace(&self.diag)?,
-                Ordering::Less | Ordering::Equal
+                lhs.compare(rhs).with_backtrace(&self.diag)?,
+                Some(Ordering::Less | Ordering::Equal)
             ))),
             BinOp::Gt => Ok(Value::Bool(matches!(
-                lhs.cmp(rhs).with_backtrace(&self.diag)?,
-                Ordering::Greater
+                lhs.compare(rhs).with_backtrace(&self.diag)?,
+                Some(Ordering::Greater)
             ))),
             BinOp::GEq => Ok(Value::Bool(matches!(
-                lhs.cmp(rhs).with_backtrace(&self.diag)?,
-                Ordering::Greater | Ordering::Equal
+                lhs.compare(rhs).with_backtrace(&self.diag)?,
+                Some(Ordering::Greater | Ordering::Equal)
             ))),
             BinOp::LShift => lhs << rhs,
             BinOp::RShift => lhs >> rhs,
             BinOp::Mul => lhs * rhs,
             BinOp::Div => lhs / rhs,
             BinOp::Mod => lhs % rhs,
-            BinOp::Plus | BinOp::Minus => return self.plus_minus(lhs, op, rhs),
+            BinOp::Plus | BinOp::Minus => return self.plus_minus(lhs, lhs_typ, op, rhs, rhs_typ),
         };
 
         ret.with_backtrace(&self.diag)
@@ -1410,10 +1761,10 @@ impl<'ir> ConstEvaluator<'ir> {
                         Value::USize(len_) => {
                             len = Some(*len_);
                         }
-                        Value::Str(r, offset) => {
+                        Value::Bytes(r, offset) => {
                             buf = r.get(*offset..);
                         }
-                        Value::Pointer(LValue::Index(r, offset)) => {
+                        Value::Pointer(LValue::Index(r, offset), _) => {
                             let r = self.materialize_lvalue(**r).unwrap();
                             if let Value::Array(elems) = r {
                                 let mut bytes = Vec::with_capacity(elems.len());
@@ -1433,7 +1784,7 @@ impl<'ir> ConstEvaluator<'ir> {
                 }
 
                 if let (Some(buf), Some(len)) = (buf, len) {
-                    Some(&buf[..len])
+                    buf.get(..len)
                 } else {
                     None
                 }
@@ -1445,7 +1796,7 @@ impl<'ir> ConstEvaluator<'ir> {
 
 fn check_lvalue_leak(value: &Value<'_>) -> Result<(), ConstEvalErrorKind> {
     match value {
-        Value::Pointer(lvalue) | Value::LValue(lvalue) => check_lvalue_leak_lvalue(lvalue),
+        Value::Pointer(lvalue, _) | Value::LValue(lvalue) => check_lvalue_leak_lvalue(lvalue),
         Value::Tuple(values) => values.iter().try_for_each(check_lvalue_leak),
         Value::Struct(fields) => fields
             .iter()
@@ -1541,8 +1892,10 @@ pub fn make_zeroed<'ir>(ir: &'ir IrCtx<'ir>, typ: TyP<'ir>) -> Value<'ir> {
             BuiltinType::I32 => Value::I32(0),
             BuiltinType::I64 => Value::I64(0),
             BuiltinType::I128 => Value::I128(0),
-            BuiltinType::F32 => Value::F32("0"),
-            BuiltinType::F64 => Value::F64("0"),
+
+            // All 0 bit patterns are valid for floats (representing +0.0)
+            BuiltinType::F32 => Value::F32(0.0),
+            BuiltinType::F64 => Value::F64(0.0),
         },
     }
 }

--- a/src/alumina-boot/src/ir/layout.rs
+++ b/src/alumina-boot/src/ir/layout.rs
@@ -1,5 +1,5 @@
 use crate::ast::{Attribute, BuiltinType};
-use crate::common::{CodeErrorKind, CycleGuardian};
+use crate::common::{CodeDiagnostic, CycleGuardian};
 use crate::global_ctx::GlobalCtx;
 use crate::ir::{IRItem, IRItemP, Ty, TyP};
 
@@ -93,7 +93,7 @@ impl<'ir> Layouter<'ir> {
         is_union: bool,
         is_packed: bool,
         fields: I,
-    ) -> Result<Layout, CodeErrorKind>
+    ) -> Result<Layout, CodeDiagnostic>
     where
         I: IntoIterator<Item = TyP<'ir>>,
     {
@@ -127,7 +127,7 @@ impl<'ir> Layouter<'ir> {
         is_union: bool,
         is_packed: bool,
         fields: I,
-    ) -> Result<FieldLayout<T>, CodeErrorKind>
+    ) -> Result<FieldLayout<T>, CodeDiagnostic>
     where
         I: IntoIterator<Item = (T, TyP<'ir>)>,
     {
@@ -169,11 +169,11 @@ impl<'ir> Layouter<'ir> {
         Ok((Layout::new(final_size, align), result))
     }
 
-    pub fn layout_of_item(&self, item: IRItemP<'ir>) -> Result<Layout, CodeErrorKind> {
+    pub fn layout_of_item(&self, item: IRItemP<'ir>) -> Result<Layout, CodeDiagnostic> {
         let _guard = self
             .cycle_guardian
             .guard(item)
-            .map_err(|_| CodeErrorKind::TypeWithInfiniteSize)?;
+            .map_err(|_| CodeDiagnostic::TypeWithInfiniteSize)?;
 
         let ret = match item.get()? {
             IRItem::StructLike(s) | IRItem::Closure(Closure { data: s, .. }) => {
@@ -206,7 +206,7 @@ impl<'ir> Layouter<'ir> {
         Ok(ret)
     }
 
-    pub fn layout_of(&self, ty: TyP<'ir>) -> Result<Layout, CodeErrorKind> {
+    pub fn layout_of(&self, ty: TyP<'ir>) -> Result<Layout, CodeDiagnostic> {
         match ty {
             Ty::Array(inner, len) => {
                 let inner_layout = self.layout_of(inner)?;

--- a/src/alumina-boot/src/ir/mono.rs
+++ b/src/alumina-boot/src/ir/mono.rs
@@ -2,7 +2,7 @@ use crate::ast::lang::LangItemKind;
 use crate::ast::rebind::Rebinder;
 use crate::ast::{Attribute, BuiltinType, Span, TestMetadata};
 use crate::common::{
-    ice, AluminaError, ArenaAllocatable, CodeErrorBuilder, CodeErrorKind, CycleGuardian, HashMap,
+    ice, AluminaError, ArenaAllocatable, CodeDiagnostic, CodeErrorBuilder, CycleGuardian, HashMap,
     HashSet, Marker,
 };
 use crate::diagnostics::DiagnosticsStack;
@@ -10,7 +10,6 @@ use crate::global_ctx::GlobalCtx;
 use crate::intrinsics::{IntrinsicKind, IntrinsicValueKind};
 use crate::ir::builder::{ExpressionBuilder, TypeBuilder};
 use crate::ir::const_eval::{numeric_of_kind, Value};
-use crate::ir::elide_zst::ZstElider;
 use crate::ir::infer::TypeInferer;
 use crate::ir::inline::IrInliner;
 use crate::ir::lang::LangTypeKind;
@@ -30,14 +29,14 @@ use super::layout::Layouter;
 
 macro_rules! mismatch {
     ($self:expr, $expected:literal, $actual:expr) => {
-        $self.diag.err(crate::common::CodeErrorKind::TypeMismatch(
+        $self.diag.err(crate::common::CodeDiagnostic::TypeMismatch(
             format!("{}", $expected),
             $self.mono_ctx.type_name($actual).unwrap(),
         ))
     };
 
     ($self:expr, $expected:expr, $actual:expr) => {
-        $self.diag.err(crate::common::CodeErrorKind::TypeMismatch(
+        $self.diag.err(crate::common::CodeDiagnostic::TypeMismatch(
             $self.mono_ctx.type_name($expected).unwrap(),
             $self.mono_ctx.type_name($actual).unwrap(),
         ))
@@ -446,7 +445,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
         if !generic_args.is_empty() {
             bail!(
                 self,
-                CodeErrorKind::GenericParamCountMismatch(0, generic_args.len())
+                CodeDiagnostic::GenericParamCountMismatch(0, generic_args.len())
             );
         }
 
@@ -464,10 +463,11 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             let expr = child.lower_expr(m.value.unwrap(), type_hint)?;
             match expr.ty {
                 ir::Ty::Builtin(b) if b.is_integer() => {}
-                _ => bail!(self, CodeErrorKind::InvalidValueForEnumVariant),
+                _ => bail!(self, CodeDiagnostic::InvalidValueForEnumVariant),
             };
 
             let value = ir::const_eval::ConstEvaluator::new(
+                child.mono_ctx.global_ctx.clone(),
                 child.diag.fork(),
                 child.mono_ctx.malloc_bag.clone(),
                 child.mono_ctx.ir,
@@ -480,7 +480,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             }
 
             if !taken_values.insert(value) {
-                bail!(self, CodeErrorKind::DuplicateEnumMember);
+                bail!(self, CodeDiagnostic::DuplicateEnumMember);
             }
 
             members.push(ir::EnumMember {
@@ -505,6 +505,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                     break counter;
                 }
                 counter = ir::const_eval::ConstEvaluator::new(
+                    child.mono_ctx.global_ctx.clone(),
                     child.diag.fork(),
                     child.mono_ctx.malloc_bag.clone(),
                     child.mono_ctx.ir,
@@ -533,6 +534,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             name: en.name.map(|n| n.alloc_on(child.mono_ctx.ir)),
             underlying_type: enum_type,
             members: members.alloc_on(child.mono_ctx.ir),
+            span: en.span,
         });
 
         item.assign(res);
@@ -552,7 +554,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
         if generic_args.len() != placeholders.len() {
             bail!(
                 self,
-                CodeErrorKind::GenericParamCountMismatch(placeholders.len(), generic_args.len())
+                CodeDiagnostic::GenericParamCountMismatch(placeholders.len(), generic_args.len())
             );
         }
 
@@ -618,6 +620,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             fields: fields.alloc_on(child.mono_ctx.ir),
             attributes: s.attributes.alloc_on(child.mono_ctx.ir),
             is_union: s.is_union,
+            span: s.span,
         });
         item.assign(res);
 
@@ -663,7 +666,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
 
         let target = s
             .target
-            .ok_or_else(|| self.diag.err(CodeErrorKind::TypedefWithoutTarget))?;
+            .ok_or_else(|| self.diag.err(CodeDiagnostic::TypedefWithoutTarget))?;
 
         let inner = child.lower_type_unrestricted(target)?;
 
@@ -711,7 +714,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
         for m in s.associated_fns {
             let fun = m.item.get_function();
             if !fun.placeholders.is_empty() {
-                bail!(self, CodeErrorKind::MixinOnlyProtocol);
+                bail!(self, CodeDiagnostic::MixinOnlyProtocol);
             }
 
             let mut param_types = Vec::new();
@@ -730,6 +733,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
         let res = ir::IRItem::Protocol(ir::Protocol {
             name: s.name.map(|n| n.alloc_on(child.mono_ctx.ir)),
             methods: methods.alloc_on(child.mono_ctx.ir),
+            span: s.span,
         });
         item.assign(res);
 
@@ -762,7 +766,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                     if negated {
                         bail!(
                             self,
-                            CodeErrorKind::ProtocolMatch(
+                            CodeDiagnostic::ProtocolMatch(
                                 self.mono_ctx.type_name(typ).unwrap(),
                                 self.mono_ctx.type_name(bound).unwrap()
                             )
@@ -775,7 +779,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                     }
                     bail!(
                         self,
-                        CodeErrorKind::ProtocolMismatch(
+                        CodeDiagnostic::ProtocolMismatch(
                             self.mono_ctx.type_name(typ).unwrap(),
                             self.mono_ctx.type_name(bound).unwrap()
                         )
@@ -787,7 +791,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                     }
                     bail!(
                         self,
-                        CodeErrorKind::ProtocolMismatchDetail(
+                        CodeDiagnostic::ProtocolMismatchDetail(
                             self.mono_ctx.type_name(typ).unwrap(),
                             self.mono_ctx.type_name(bound).unwrap(),
                             detail
@@ -808,7 +812,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
 
             bail!(
                 self,
-                CodeErrorKind::ProtocolMismatch(
+                CodeDiagnostic::ProtocolMismatch(
                     self.mono_ctx.type_name(typ).unwrap(),
                     bounds
                         .iter()
@@ -857,7 +861,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
         let protocol_item = match bound {
             ir::Ty::Item(protocol) => match protocol.get() {
                 Ok(ir::IRItem::Protocol(_)) => protocol,
-                Err(_) => bail!(self, CodeErrorKind::CyclicProtocolBound),
+                Err(_) => bail!(self, CodeDiagnostic::CyclicProtocolBound),
                 _ => {
                     if bound == ty {
                         return Ok(BoundCheckResult::Matches);
@@ -1153,9 +1157,9 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                     if code.iter().all(|c| {
                         matches!(
                             c.kind,
-                            CodeErrorKind::ProtocolMatch(_, _)
-                                | CodeErrorKind::ProtocolMismatch(_, _)
-                                | CodeErrorKind::ProtocolMismatchDetail(_, _, _)
+                            CodeDiagnostic::ProtocolMatch(_, _)
+                                | CodeDiagnostic::ProtocolMismatch(_, _)
+                                | CodeDiagnostic::ProtocolMismatchDetail(_, _, _)
                         )
                     }) =>
                 {
@@ -1232,6 +1236,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             };
 
             let value = ir::const_eval::ConstEvaluator::new(
+                child.mono_ctx.global_ctx.clone(),
                 child.diag.fork(),
                 child.mono_ctx.malloc_bag.clone(),
                 child.mono_ctx.ir,
@@ -1239,16 +1244,11 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             )
             .const_eval(init)?;
 
-            let mut elider = ZstElider::new(self.diag.fork(), child.mono_ctx.ir);
-            // TODO(tibordp): check that elider didn't produce any temporary local variables.
-            // It should never happen, but what do you know.
-            let optimized =
-                elider.elide_zst_expr(child.exprs.literal(value, init.ty, init.span))?;
-
             let res = ir::IRItem::Const(ir::Const {
                 name: s.name.map(|n| n.alloc_on(child.mono_ctx.ir)),
                 typ: init.ty,
-                init: optimized,
+                init: child.exprs.literal(value, init.ty, init.span),
+                span: s.span,
                 value,
             });
 
@@ -1264,6 +1264,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                 typ,
                 init,
                 attributes: s.attributes.alloc_on(child.mono_ctx.ir),
+                span: s.span,
                 r#extern: s.r#extern,
             });
             item.assign(res);
@@ -1326,6 +1327,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             attributes: func.attributes.alloc_on(child.mono_ctx.ir),
             args: parameters.alloc_on(child.mono_ctx.ir),
             varargs: func.varargs,
+            span: func.span,
             return_type,
             body: OnceCell::new(),
         });
@@ -1374,7 +1376,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             }
             _ => bail!(
                 self,
-                CodeErrorKind::NotAProtocol(format!("{:?}", mixin.protocol))
+                CodeDiagnostic::NotAProtocol(format!("{:?}", mixin.protocol))
             ),
         };
 
@@ -1384,7 +1386,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
         if protocol.placeholders.len() != generic_args.len() {
             bail!(
                 self,
-                CodeErrorKind::GenericParamCountMismatch(
+                CodeDiagnostic::GenericParamCountMismatch(
                     protocol.placeholders.len(),
                     generic_args.len()
                 )
@@ -1481,41 +1483,37 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
         let body = self.try_coerce(return_type, body)?;
         if is_ir_inline {
             if self.defer_context.is_some() {
-                bail!(self, CodeErrorKind::IrInlineFlowControl);
+                bail!(self, CodeDiagnostic::IrInlineFlowControl);
             }
             if !self.local_defs.is_empty() {
-                bail!(self, CodeErrorKind::IrInlineLocalDefs);
+                bail!(self, CodeDiagnostic::IrInlineLocalDefs);
             }
         };
 
-        let mut statements = Vec::new();
-        if self.defer_context.is_some() {
+        let body = if self.defer_context.is_some() {
+            let mut statements = Vec::new();
             self.generate_defer_prologue(&mut statements);
-        }
-
-        if let ir::ExprKind::Block(block, ret) = body.kind {
-            statements.extend(block.iter().cloned());
-            statements.push(ir::Statement::Expression(self.make_return(ret, ret.span)?));
-        } else {
-            statements.push(ir::Statement::Expression(
-                self.make_return(body, body.span)?,
-            ));
-        };
-
-        if self.defer_context.is_some() {
+            if let ir::ExprKind::Block(block, ret) = body.kind {
+                statements.extend(block.iter().cloned());
+                statements.push(ir::Statement::Expression(self.make_return(ret, ret.span)?));
+            } else {
+                statements.push(ir::Statement::Expression(
+                    self.make_return(body, body.span)?,
+                ));
+            };
             self.generate_defer_epilogue(&mut statements);
-        }
+            self.exprs
+                .block(statements, self.exprs.unreachable(None), body.span)
+        } else {
+            body
+        };
 
         let function_body = FuncBody {
-            statements: statements.alloc_on(self.mono_ctx.ir),
             local_defs: self.local_defs.alloc_on(self.mono_ctx.ir),
-            raw_body: Some(body),
+            expr: body,
         };
 
-        let elider = ZstElider::new(self.diag.fork(), self.mono_ctx.ir);
-        let optimized = elider.elide_zst_func_body(function_body)?;
-
-        Ok(optimized)
+        Ok(function_body)
     }
 
     pub fn get_mono_key(
@@ -1552,7 +1550,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             .mono_ctx
             .cycle_guardian
             .guard((item, generic_args))
-            .map_err(|_| self.diag.err(CodeErrorKind::CycleDetected))?;
+            .map_err(|_| self.diag.err(CodeDiagnostic::CycleDetected))?;
 
         let mut args: Vec<_> = generic_args.to_vec();
         for placeholder in placeholders.iter().skip(generic_args.len()) {
@@ -1604,7 +1602,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                     if entry.get().get().is_err() {
                         match key.0.get() {
                             ast::Item::StaticOrConst(_) => {
-                                bail!(self, CodeErrorKind::RecursiveStaticInitialization)
+                                bail!(self, CodeDiagnostic::RecursiveStaticInitialization)
                             }
                             _ => {}
                         }
@@ -1644,7 +1642,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                 if !self.tentative && func.attributes.contains(&ast::Attribute::Test) {
                     let fun = item.get_function().unwrap();
                     if !fun.args.is_empty() || fun.return_type != self.types.void() {
-                        bail!(self, CodeErrorKind::InvalidTestCaseSignature);
+                        bail!(self, CodeDiagnostic::InvalidTestCaseSignature);
                     }
 
                     let metadata = self.mono_ctx.ast.test_metadata(key.0).unwrap();
@@ -1717,22 +1715,10 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             None,
         );
 
-        let mut statements = Vec::new();
-        if let ir::ExprKind::Block(block, ret) = body.kind {
-            statements.extend(block.iter().cloned());
-            statements.push(ir::Statement::Expression(self.make_return(ret, None)?));
-        } else {
-            statements.push(ir::Statement::Expression(self.make_return(body, None)?));
-        };
-
         let function_body = FuncBody {
-            statements: statements.alloc_on(self.mono_ctx.ir),
             local_defs: local_defs.alloc_on(self.mono_ctx.ir),
-            raw_body: None,
+            expr: body,
         };
-
-        let elider = ZstElider::new(self.diag.fork(), self.mono_ctx.ir);
-        let optimized = elider.elide_zst_func_body(function_body)?;
 
         item.assign(ir::IRItem::Function(ir::Function {
             name: None,
@@ -1740,7 +1726,8 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             args: [].alloc_on(self.mono_ctx.ir),
             return_type: self.types.void(),
             varargs: false,
-            body: OnceCell::from(optimized),
+            span: None,
+            body: OnceCell::from(function_body),
         }));
 
         Ok(item)
@@ -1788,7 +1775,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             if let Ok(ir::IRItem::Protocol(_)) = item.get() {
                 bail!(
                     self,
-                    CodeErrorKind::ProtocolsAreSpecialMkay(self.mono_ctx.type_name(typ).unwrap())
+                    CodeDiagnostic::ProtocolsAreSpecialMkay(self.mono_ctx.type_name(typ).unwrap())
                 );
             }
         }
@@ -1805,7 +1792,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
         macro_rules! arg_count {
             ($count:expr) => {
                 if args.len() != $count {
-                    bail!(self, CodeErrorKind::InvalidTypeOperator);
+                    bail!(self, CodeDiagnostic::InvalidTypeOperator);
                 }
             };
         }
@@ -1842,7 +1829,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                         }
                     }
                 }
-                bail!(self, CodeErrorKind::InvalidTypeOperator);
+                bail!(self, CodeDiagnostic::InvalidTypeOperator);
             }
             Some(LangItemKind::TypeopGenericArgsOf) => {
                 arg_count!(1);
@@ -1857,7 +1844,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                     }
                     _ => {}
                 }
-                bail!(self, CodeErrorKind::InvalidTypeOperator);
+                bail!(self, CodeDiagnostic::InvalidTypeOperator);
             }
             Some(LangItemKind::TypeopReturnTypeOf) => {
                 arg_count!(1);
@@ -1924,7 +1911,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             _ => return Ok(None),
         };
 
-        Err(self.diag.err(CodeErrorKind::InvalidTypeOperator))
+        Err(self.diag.err(CodeDiagnostic::InvalidTypeOperator))
     }
 
     fn lower_type_unrestricted(
@@ -1939,6 +1926,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                 let len_expr =
                     child.lower_expr(len, Some(child.types.builtin(BuiltinType::USize)))?;
                 let len = ir::const_eval::ConstEvaluator::new(
+                    child.mono_ctx.global_ctx.clone(),
                     child.diag.fork(),
                     child.mono_ctx.malloc_bag.clone(),
                     child.mono_ctx.ir,
@@ -1993,7 +1981,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                 self.types.tuple(items)
             }
             ast::Ty::Placeholder(id) => self.replacements.get(&id).copied().ok_or_else(|| {
-                self.diag.err(CodeErrorKind::InternalError(
+                self.diag.err(CodeDiagnostic::InternalError(
                     "unbound placeholder".to_string(),
                     Backtrace::capture().into(),
                 ))
@@ -2001,7 +1989,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             ast::Ty::Item(item) => match self.mono_ctx.ast.lang_item_kind(item) {
                 Some(LangItemKind::ImplBuiltin(kind)) => self.types.builtin(kind),
                 Some(LangItemKind::ImplArray | LangItemKind::ImplTuple(..)) => {
-                    bail!(self, CodeErrorKind::BuiltinTypesAreSpecialMkay);
+                    bail!(self, CodeDiagnostic::BuiltinTypesAreSpecialMkay);
                 }
                 _ => {
                     let item = self.monomorphize_item(item, &[])?;
@@ -2066,13 +2054,13 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
 
                             if let Some(p) = self.mono_ctx.ast.lang_item_kind(ast_item) {
                                 if p.is_builtin_protocol() {
-                                    bail!(self, CodeErrorKind::BuiltinProtocolDyn);
+                                    bail!(self, CodeDiagnostic::BuiltinProtocolDyn);
                                 }
                             }
 
                             protocol_items.push(*protocol_item)
                         }
-                        _ => bail!(self, CodeErrorKind::NonProtocolDyn),
+                        _ => bail!(self, CodeDiagnostic::NonProtocolDyn),
                     };
                 }
 
@@ -2157,7 +2145,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                     () => {
                         bail!(
                             self,
-                            CodeErrorKind::NonDynnableFunction(proto_fun.name.to_string())
+                            CodeDiagnostic::NonDynnableFunction(proto_fun.name.to_string())
                         )
                     };
                 }
@@ -2458,7 +2446,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
 
                         return Ok(result.alloc_on(self.mono_ctx.ir));
                     }
-                    ir::IRItem::Closure(_) => bail!(self, CodeErrorKind::ClosuresAreNotFns),
+                    ir::IRItem::Closure(_) => bail!(self, CodeDiagnostic::ClosuresAreNotFns),
                     _ => {}
                 }
             }
@@ -2600,7 +2588,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             if fun.args.len() != args.len() + self_count {
                 bail!(
                     self,
-                    CodeErrorKind::ParamCountMismatch(fun.args.len() - self_count, args.len())
+                    CodeDiagnostic::ParamCountMismatch(fun.args.len() - self_count, args.len())
                 );
             }
 
@@ -2613,11 +2601,9 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                     .filter_map(|(p, e)| match child.lower_expr(e, None) {
                         Ok(e) => Some(Ok((p.typ, e.ty))),
                         Err(AluminaError::CodeErrors(errors)) => {
-                            tentative_errors.extend(
-                                errors.into_iter().filter(|f| {
-                                    !matches!(f.kind, CodeErrorKind::TypeInferenceFailed)
-                                }),
-                            );
+                            tentative_errors.extend(errors.into_iter().filter(|f| {
+                                !matches!(f.kind, CodeDiagnostic::TypeInferenceFailed)
+                            }));
                             None
                         }
                         Err(e) => Some(Err(e)),
@@ -2653,7 +2639,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             Some(generic_args) => {
                 self.monomorphize_item(item, generic_args.alloc_on(self.mono_ctx.ir))
             }
-            None => Err(self.diag.err(CodeErrorKind::TypeInferenceFailed)),
+            None => Err(self.diag.err(CodeDiagnostic::TypeInferenceFailed)),
         }
     }
 
@@ -2670,14 +2656,14 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                 let lowered = self.lower_type_for_value(typ)?;
                 match lowered {
                     ir::Ty::Item(item) if item.is_struct_like() => return Ok(item),
-                    _ => bail!(self, CodeErrorKind::StructLikeExpectedHere),
+                    _ => bail!(self, CodeDiagnostic::StructLikeExpectedHere),
                 }
             }
         };
 
         let r#struct = match item.get() {
             ast::Item::StructLike(s) => s,
-            _ => bail!(self, CodeErrorKind::StructLikeExpectedHere),
+            _ => bail!(self, CodeDiagnostic::StructLikeExpectedHere),
         };
 
         if let Some(generic_args) = generic_args {
@@ -2723,7 +2709,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                     tentative_errors.extend(
                         errors
                             .into_iter()
-                            .filter(|f| !matches!(f.kind, CodeErrorKind::TypeInferenceFailed)),
+                            .filter(|f| !matches!(f.kind, CodeDiagnostic::TypeInferenceFailed)),
                     );
                     None
                 }
@@ -2746,7 +2732,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             Some(generic_args) => {
                 self.monomorphize_item(item, generic_args.alloc_on(self.mono_ctx.ir))
             }
-            None => Err(self.diag.err(CodeErrorKind::TypeInferenceFailed)),
+            None => Err(self.diag.err(CodeDiagnostic::TypeInferenceFailed)),
         }
     }
 
@@ -2864,6 +2850,13 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                 self.types.builtin(BuiltinType::Bool)
             }
 
+            // Function pointer equality comparison only
+            (FunctionPointer(l_a, l_b), Eq | Neq, FunctionPointer(r_a, r_b))
+                if *l_a == *r_a && l_b == r_b =>
+            {
+                self.types.builtin(BuiltinType::Bool)
+            }
+
             // Bit shifts
             (Builtin(l), LShift | RShift, Builtin(r)) if l.is_integer() && r.is_integer() => lhs.ty,
 
@@ -2877,7 +2870,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
 
             _ => bail!(
                 self,
-                CodeErrorKind::InvalidBinOp(
+                CodeDiagnostic::InvalidBinOp(
                     op,
                     self.mono_ctx.type_name(lhs.ty).unwrap(),
                     self.mono_ctx.type_name(rhs.ty).unwrap()
@@ -2908,11 +2901,11 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
 
                 if must_use && !self.tentative {
                     let type_name = self.mono_ctx.type_name(expr.ty)?;
-                    self.diag.warn(CodeErrorKind::UnusedMustUse(type_name))
+                    self.diag.warn(CodeDiagnostic::UnusedMustUse(type_name))
                 }
 
                 if expr.pure() && !expr.is_void() {
-                    self.diag.warn(CodeErrorKind::PureStatement);
+                    self.diag.warn(CodeDiagnostic::PureStatement);
                 }
 
                 Some(ir::Statement::Expression(expr))
@@ -2931,7 +2924,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                     .transpose()?;
 
                 match (type_hint, init) {
-                    (None, None) => bail!(self, CodeErrorKind::TypeHintRequired),
+                    (None, None) => bail!(self, CodeDiagnostic::TypeHintRequired),
                     (Some(ty), None) => {
                         self.local_types.insert(id, ty);
                         self.local_defs.push(ir::LocalDef { id, typ: ty });
@@ -3027,8 +3020,21 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
 
         let ret = self.lower_expr(ret, type_hint)?;
 
+        let mut never_return = false;
+
         Ok(self.exprs.block(
-            statements.into_iter().flat_map(|e| e.unwrap()),
+            statements.into_iter().flat_map(|e| e.unwrap()).map(|s| {
+                if let ir::Statement::Expression(expr) = s {
+                    if never_return {
+                        let _guard = self.diag.push_span(expr.span);
+                        self.diag.warn(CodeDiagnostic::DeadCode);
+                    } else if expr.diverges() {
+                        never_return = true
+                    }
+                }
+
+                s
+            }),
             ret,
             ast_span,
         ))
@@ -3085,7 +3091,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
 
                 Err(self
                     .diag
-                    .err(CodeErrorKind::IntegerOutOfRange(value, type_name)))
+                    .err(CodeDiagnostic::IntegerOutOfRange(value, type_name)))
             }
         }
     }
@@ -3127,14 +3133,26 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                     _ => self.types.builtin(BuiltinType::F64),
                 };
 
-                let ir_str = v.alloc_on(self.mono_ctx.ir);
-
                 match ty {
                     ir::Ty::Builtin(BuiltinType::F32) => {
-                        self.exprs.literal(Value::F32(ir_str), ty, ast_span)
+                        let v = v.parse().or_else(|_| {
+                            let type_name = self.mono_ctx.type_name(ty)?;
+                            Err(self
+                                .diag
+                                .err(CodeDiagnostic::FloatOutOfRange(v.to_string(), type_name)))
+                        })?;
+
+                        self.exprs.literal(Value::F32(v), ty, ast_span)
                     }
                     ir::Ty::Builtin(BuiltinType::F64) => {
-                        self.exprs.literal(Value::F64(ir_str), ty, ast_span)
+                        let v = v.parse().or_else(|_| {
+                            let type_name = self.mono_ctx.type_name(ty)?;
+                            Err(self
+                                .diag
+                                .err(CodeDiagnostic::FloatOutOfRange(v.to_string(), type_name)))
+                        })?;
+
+                        self.exprs.literal(Value::F64(v), ty, ast_span)
                     }
                     _ => ice!(self.diag, "unexpected type for the float literal"),
                 }
@@ -3203,7 +3221,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             .local_types
             .get(&id)
             .copied()
-            .ok_or_else(|| self.diag.err(CodeErrorKind::LocalWithUnknownType))?;
+            .ok_or_else(|| self.diag.err(CodeDiagnostic::LocalWithUnknownType))?;
 
         Ok(self.exprs.local(id, typ, ast_span))
     }
@@ -3223,7 +3241,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             .local_types
             .get(&self_arg)
             .copied()
-            .ok_or_else(|| self.diag.err(CodeErrorKind::LocalWithUnknownType))?;
+            .ok_or_else(|| self.diag.err(CodeDiagnostic::LocalWithUnknownType))?;
 
         match typ.canonical_type() {
             ir::Ty::Item(item) => {
@@ -3318,7 +3336,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             _ => {
                 bail!(
                     self,
-                    CodeErrorKind::InvalidUnOp(op, self.mono_ctx.type_name(inner.ty).unwrap())
+                    CodeDiagnostic::InvalidUnOp(op, self.mono_ctx.type_name(inner.ty).unwrap())
                 );
             }
         };
@@ -3432,11 +3450,11 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
         }
 
         if lhs.value_type != ir::ValueType::LValue {
-            bail!(self, CodeErrorKind::CannotAssignToRValue);
+            bail!(self, CodeDiagnostic::CannotAssignToRValue);
         }
 
         if lhs.is_const {
-            bail!(self, CodeErrorKind::CannotAssignToConst);
+            bail!(self, CodeDiagnostic::CannotAssignToConst);
         }
 
         self.typecheck_binary(op, lhs, rhs)?;
@@ -3459,11 +3477,11 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
         }
 
         if lhs.value_type != ir::ValueType::LValue {
-            bail!(self, CodeErrorKind::CannotAssignToRValue);
+            bail!(self, CodeDiagnostic::CannotAssignToRValue);
         }
 
         if lhs.is_const {
-            bail!(self, CodeErrorKind::CannotAssignToConst);
+            bail!(self, CodeDiagnostic::CannotAssignToConst);
         }
 
         let rhs = self.try_coerce(lhs.ty, rhs)?;
@@ -3501,7 +3519,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                 } else {
                     bail!(
                         self,
-                        CodeErrorKind::MismatchedBranchTypes(
+                        CodeDiagnostic::MismatchedBranchTypes(
                             self.mono_ctx.type_name(then.ty).unwrap(),
                             self.mono_ctx.type_name(els.ty).unwrap()
                         )
@@ -3510,7 +3528,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             } else {
                 bail!(
                     self,
-                    CodeErrorKind::MismatchedBranchTypes(
+                    CodeDiagnostic::MismatchedBranchTypes(
                         self.mono_ctx.type_name(then.ty).unwrap(),
                         self.mono_ctx.type_name(els.ty).unwrap()
                     )
@@ -3525,6 +3543,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
         let mut const_cond = None;
         let child = self.make_tentative_child();
         match ir::const_eval::ConstEvaluator::new(
+            child.mono_ctx.global_ctx.clone(),
             child.diag.fork(),
             child.mono_ctx.malloc_bag.clone(),
             child.mono_ctx.ir,
@@ -3534,6 +3553,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
         {
             Ok(Value::Bool(for_const_eval)) => {
                 match ir::const_eval::ConstEvaluator::for_codegen(
+                    child.mono_ctx.global_ctx.clone(),
                     child.diag.fork(),
                     child.mono_ctx.malloc_bag.clone(),
                     child.mono_ctx.ir,
@@ -3544,7 +3564,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                     Ok(Value::Bool(for_codegen)) => {
                         if for_const_eval == for_codegen {
                             self.diag
-                                .warn(CodeErrorKind::ConstantCondition(for_const_eval));
+                                .warn(CodeDiagnostic::ConstantCondition(for_const_eval));
                         }
                         const_cond = Some(for_codegen);
                     }
@@ -3561,6 +3581,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
         let mut child = self.make_tentative_child();
         let ir_expr = child.lower_expr(cond, Some(child.types.builtin(BuiltinType::Bool)))?;
         let ret = ir::const_eval::ConstEvaluator::new(
+            child.mono_ctx.global_ctx.clone(),
             child.diag.fork(),
             child.mono_ctx.malloc_bag.clone(),
             child.mono_ctx.ir,
@@ -3613,6 +3634,18 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
         } else {
             self.lower_expr(els, type_hint)
         }
+    }
+
+    fn lower_tag(
+        &mut self,
+        tag: &'ast str,
+        inner: ast::ExprP<'ast>,
+        type_hint: Option<ir::TyP<'ir>>,
+        ast_span: Option<Span>,
+    ) -> Result<ir::ExprP<'ir>, AluminaError> {
+        let inner: &ir::Expr = self.lower_expr(inner, type_hint)?;
+
+        Ok(self.exprs.tag(tag, inner, ast_span))
     }
 
     fn lower_tuple(
@@ -3761,7 +3794,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
 
             _ => bail!(
                 self,
-                CodeErrorKind::InvalidCast(
+                CodeDiagnostic::InvalidCast(
                     self.mono_ctx.type_name(expr.ty).unwrap(),
                     self.mono_ctx.type_name(typ).unwrap()
                 )
@@ -3830,7 +3863,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             .loop_contexts
             .last()
             .cloned()
-            .ok_or_else(|| self.diag.err(CodeErrorKind::BreakOutsideOfLoop))?;
+            .ok_or_else(|| self.diag.err(CodeDiagnostic::BreakOutsideOfLoop))?;
 
         let expr = expr
             .map(|e| self.lower_expr(e, loop_context.type_hint))
@@ -3883,7 +3916,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             .loop_contexts
             .last()
             .cloned()
-            .ok_or_else(|| self.diag.err(CodeErrorKind::ContinueOutsideOfLoop))?;
+            .ok_or_else(|| self.diag.err(CodeDiagnostic::ContinueOutsideOfLoop))?;
 
         Ok(self.exprs.goto(loop_context.continue_label, ast_span))
     }
@@ -3895,20 +3928,6 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
         generic_args: &[ast::TyP<'ast>],
         args: &[ast::ExprP<'ast>],
     ) -> Result<ir::ExprP<'ir>, AluminaError> {
-        if callee.generic_count != generic_args.len() {
-            bail!(
-                self,
-                CodeErrorKind::GenericParamCountMismatch(callee.generic_count, generic_args.len())
-            );
-        }
-
-        if (callee.arg_count != args.len()) && !(callee.varargs && args.len() >= callee.arg_count) {
-            bail!(
-                self,
-                CodeErrorKind::ParamCountMismatch(callee.arg_count, args.len())
-            );
-        }
-
         let generic_args = generic_args
             .iter()
             .map(|e| self.lower_type_unrestricted(e))
@@ -3919,11 +3938,29 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             .map(|e| self.lower_expr(e, None))
             .collect::<Result<Vec<_>, _>>()?;
 
+        macro_rules! arg {
+            ($n:literal) => {
+                match args.get($n) {
+                    Some(arg) => arg,
+                    None => ice!(self.diag, "not enough arguments to intrinsic"),
+                }
+            };
+        }
+
+        macro_rules! generic {
+            ($n:literal) => {
+                match generic_args.get($n) {
+                    Some(arg) => arg,
+                    None => ice!(self.diag, "not enough generic arguments to intrinsic"),
+                }
+            };
+        }
+
         match callee.kind {
             IntrinsicKind::TestCases => self.generate_test_cases(),
             IntrinsicKind::MakeVtable => {
-                if let ir::Ty::Tuple(inner) = generic_args[0] {
-                    self.generate_vtable(inner, generic_args[1])
+                if let ir::Ty::Tuple(inner) = generic!(0) {
+                    self.generate_vtable(inner, generic!(1))
                 } else {
                     ice!(
                         self.diag,
@@ -3931,40 +3968,40 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                     )
                 }
             }
-            IntrinsicKind::EnumVariants => self.generate_enum_variants(generic_args[0]),
+            IntrinsicKind::EnumVariants => self.generate_enum_variants(generic!(0)),
             IntrinsicKind::TypeName => {
-                let typ = generic_args[0];
+                let typ = generic!(0);
                 let name = self.mono_ctx.type_name(typ)?;
                 Ok(self.string_of(name.as_bytes(), span)?)
             }
-            IntrinsicKind::SizeOf => self.size_of(generic_args[0], span),
-            IntrinsicKind::AlignOf => self.align_of(generic_args[0], span),
-            IntrinsicKind::TypeId => self.type_id(generic_args[0], span),
-            IntrinsicKind::ArrayLengthOf => self.array_length_of(generic_args[0], span),
+            IntrinsicKind::SizeOf => self.size_of(generic!(0), span),
+            IntrinsicKind::AlignOf => self.align_of(generic!(0), span),
+            IntrinsicKind::TypeId => self.type_id(generic!(0), span),
+            IntrinsicKind::ArrayLengthOf => self.array_length_of(generic!(0), span),
             IntrinsicKind::Trap => self.trap(span),
-            IntrinsicKind::CompileFail => self.compile_fail(args[0], span),
-            IntrinsicKind::CompileWarn => self.compile_warn(args[0], span),
-            IntrinsicKind::CompileNote => self.compile_note(args[0], span),
+            IntrinsicKind::Transmute => self.transmute(generic!(1), arg!(0), span),
+            IntrinsicKind::CompileFail => self.compile_fail(arg!(0), span),
+            IntrinsicKind::CompileWarn => self.compile_warn(arg!(0), span),
+            IntrinsicKind::CompileNote => self.compile_note(arg!(0), span),
             IntrinsicKind::Unreachable => self.unreachable(span),
-            IntrinsicKind::Asm => self.asm(args[0], span),
-            IntrinsicKind::CodegenFunc => {
-                self.codegen_func(args[0], &args[1..], generic_args[0], span)
-            }
-            IntrinsicKind::CodegenConst => self.codegen_const(args[0], generic_args[0], span),
+            IntrinsicKind::Asm => self.asm(arg!(0), span),
+            IntrinsicKind::CodegenFunc => self.codegen_func(arg!(0), &args[1..], generic!(0), span),
+            IntrinsicKind::CodegenConst => self.codegen_const(arg!(0), generic!(0), span),
             IntrinsicKind::CodegenTypeFunc => {
-                self.codegen_type_func(args[0], generic_args[0], generic_args[1], span)
+                self.codegen_type_func(arg!(0), generic!(0), generic!(1), span)
             }
-            IntrinsicKind::Uninitialized => self.uninitialized(generic_args[0], span),
-            IntrinsicKind::Zeroed => self.zeroed(generic_args[0], span),
-            IntrinsicKind::Dangling => self.dangling(generic_args[0], span),
+            IntrinsicKind::Uninitialized => self.uninitialized(generic!(0), span),
+            IntrinsicKind::Zeroed => self.zeroed(generic!(0), span),
+            IntrinsicKind::Dangling => self.dangling(generic!(0), span),
             IntrinsicKind::InConstContext => self.in_const_context(span),
-            IntrinsicKind::ConstEval => self.const_eval(args[0], span),
-            IntrinsicKind::ConstPanic => self.const_panic(args[0], span),
-            IntrinsicKind::ConstWarning => self.const_write(args[0], true, span),
-            IntrinsicKind::ConstNote => self.const_write(args[0], false, span),
-            IntrinsicKind::ConstAlloc => self.const_alloc(generic_args[0], args[0], span),
-            IntrinsicKind::ConstFree => self.const_free(args[0], span),
-            IntrinsicKind::IsConstEvaluable => self.is_const_evaluable(args[0], span),
+            IntrinsicKind::ConstEval => self.const_eval(arg!(0), span),
+            IntrinsicKind::ConstPanic => self.const_panic(arg!(0), span),
+            IntrinsicKind::Tag => self.tag(arg!(0), arg!(1), span),
+            IntrinsicKind::ConstWarning => self.const_write(arg!(0), true, span),
+            IntrinsicKind::ConstNote => self.const_write(arg!(0), false, span),
+            IntrinsicKind::ConstAlloc => self.const_alloc(generic!(0), arg!(0), span),
+            IntrinsicKind::ConstFree => self.const_free(arg!(0), span),
+            IntrinsicKind::IsConstEvaluable => self.is_const_evaluable(arg!(0), span),
         }
     }
 
@@ -3996,7 +4033,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
         let make_slice = self.monomorphize_lang_item(LangItemKind::SliceNew, [ptr_type])?;
 
         let data = self.exprs.literal(
-            Value::Str(self.mono_ctx.ir.arena.alloc_slice_copy(value), 0),
+            Value::Bytes(self.mono_ctx.ir.arena.alloc_slice_copy(value), 0),
             ptr_type,
             span,
         );
@@ -4039,9 +4076,8 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                         self.mono_ctx.ir,
                         func.body
                             .get()
-                            .ok_or_else(|| self.diag.err(CodeErrorKind::UnpopulatedSymbol))?
-                            .raw_body
-                            .unwrap(),
+                            .ok_or_else(|| self.diag.err(CodeDiagnostic::UnpopulatedSymbol))?
+                            .expr,
                         func.args
                             .iter()
                             .zip(args.into_iter())
@@ -4080,7 +4116,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             .vtable_layouts
             .get(protocol_types)
             .ok_or_else(|| {
-                self.diag.err(CodeErrorKind::InternalError(
+                self.diag.err(CodeDiagnostic::InternalError(
                     "vtable layout not found".to_string(),
                     Backtrace::capture().into(),
                 ))
@@ -4100,7 +4136,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
         if func.arg_types.len() != args.len() + 1 {
             bail!(
                 self,
-                CodeErrorKind::ParamCountMismatch(func.arg_types.len() - 1, args.len())
+                CodeDiagnostic::ParamCountMismatch(func.arg_types.len() - 1, args.len())
             );
         }
 
@@ -4236,7 +4272,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             .copied()
             .or(unified_fn)
             .ok_or_else(|| {
-                self.diag.err(CodeErrorKind::MethodNotFound(
+                self.diag.err(CodeDiagnostic::MethodNotFound(
                     name.into(),
                     self.mono_ctx.type_name(canonical).unwrap(),
                 ))
@@ -4265,13 +4301,13 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
         };
 
         if arg_types.is_empty() {
-            bail!(self, CodeErrorKind::NotAMethod);
+            bail!(self, CodeDiagnostic::NotAMethod);
         }
 
         if arg_types.len() != args.len() + 1 {
             bail!(
                 self,
-                CodeErrorKind::ParamCountMismatch(arg_types.len() - 1, args.len())
+                CodeDiagnostic::ParamCountMismatch(arg_types.len() - 1, args.len())
             );
         }
 
@@ -4310,7 +4346,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                         .mono_ctx
                         .cycle_guardian
                         .guard((n, &[]))
-                        .map_err(|_| self.diag.err(CodeErrorKind::CycleDetected))?;
+                        .map_err(|_| self.diag.err(CodeDiagnostic::CycleDetected))?;
 
                     return self.resolve_ast_type(target);
                 }
@@ -4335,7 +4371,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
         let associated_fns = self.get_associated_fns_for_ast(typ)?;
         let func = associated_fns.get(spec.name).ok_or_else(|| {
             self.diag
-                .err(CodeErrorKind::UnresolvedItem(spec.name.to_string()))
+                .err(CodeDiagnostic::UnresolvedItem(spec.name.to_string()))
         })?;
 
         Ok(func)
@@ -4436,25 +4472,25 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                     (&fn_arg_types[..], fun.return_type, callee)
                 }
                 _ => {
-                    bail!(self, CodeErrorKind::FunctionOrStaticExpectedHere);
+                    bail!(self, CodeDiagnostic::FunctionOrStaticExpectedHere);
                 }
             },
             _ => {
-                bail!(self, CodeErrorKind::FunctionOrStaticExpectedHere);
+                bail!(self, CodeDiagnostic::FunctionOrStaticExpectedHere);
             }
         };
 
         if !varargs && (arg_types.len() != args.len()) {
             bail!(
                 self,
-                CodeErrorKind::ParamCountMismatch(arg_types.len(), args.len())
+                CodeDiagnostic::ParamCountMismatch(arg_types.len(), args.len())
             );
         }
 
         if varargs && (arg_types.len() > args.len()) {
             bail!(
                 self,
-                CodeErrorKind::ParamCountMismatch(arg_types.len(), args.len())
+                CodeDiagnostic::ParamCountMismatch(arg_types.len(), args.len())
             );
         }
 
@@ -4515,7 +4551,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
         let result = match kind {
             ast::FnKind::Normal(item) => {
                 if let ast::Item::Intrinsic(_) = item.get() {
-                    bail!(self, CodeErrorKind::IntrinsicsAreSpecialMkay);
+                    bail!(self, CodeDiagnostic::IntrinsicsAreSpecialMkay);
                 }
 
                 let item = self.try_resolve_function(
@@ -4569,6 +4605,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                                 name: None,
                                 attributes: &[],
                                 fields: fields.clone().alloc_on(self.mono_ctx.ir),
+                                span: None,
                                 is_union: false,
                             },
                             function: OnceCell::new(),
@@ -4638,7 +4675,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
         let result = match tup.ty.canonical_type() {
             ir::Ty::Tuple(types) => {
                 if types.len() <= index {
-                    bail!(self, CodeErrorKind::TupleIndexOutOfBounds);
+                    bail!(self, CodeDiagnostic::TupleIndexOutOfBounds);
                 }
 
                 let mut tup = tup;
@@ -4674,7 +4711,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                 let field_map = self.get_struct_field_map(item)?;
                 let field = field_map.get(field).ok_or_else(|| {
                     self.diag
-                        .err(CodeErrorKind::UnresolvedItem(field.to_string()))
+                        .err(CodeDiagnostic::UnresolvedItem(field.to_string()))
                 })?;
 
                 let mut obj = obj;
@@ -4684,7 +4721,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
 
                 self.exprs.field(obj, field.id, field.ty, ast_span)
             }
-            _ => bail!(self, CodeErrorKind::StructLikeExpectedHere),
+            _ => bail!(self, CodeDiagnostic::StructLikeExpectedHere),
         };
 
         Ok(result)
@@ -4969,7 +5006,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
         ast_span: Option<Span>,
     ) -> Result<ir::ExprP<'ir>, AluminaError> {
         if self.return_type.is_none() {
-            bail!(self, CodeErrorKind::NotInAFunctionScope);
+            bail!(self, CodeDiagnostic::NotInAFunctionScope);
         }
 
         let inner = inner
@@ -4990,11 +5027,11 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
         ast_span: Option<Span>,
     ) -> Result<ir::ExprP<'ir>, AluminaError> {
         if self.return_type.is_none() {
-            bail!(self, CodeErrorKind::NotInAFunctionScope);
+            bail!(self, CodeDiagnostic::NotInAFunctionScope);
         }
 
         if !self.loop_contexts.is_empty() && !self.tentative {
-            self.diag.warn(CodeErrorKind::DeferInALoop);
+            self.diag.warn(CodeDiagnostic::DeferInALoop);
         }
 
         match self.defer_context.as_mut() {
@@ -5008,7 +5045,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                 });
                 self.defer_context = Some(ctx);
             }
-            Some(ctx) if ctx.in_defer => bail!(self, CodeErrorKind::DeferInDefer),
+            Some(ctx) if ctx.in_defer => bail!(self, CodeDiagnostic::DeferInDefer),
             Some(ctx) => ctx.in_defer = true,
         };
 
@@ -5025,7 +5062,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
         });
 
         defer_context.defered.push((defer_flag, inner));
-        Ok(self.exprs.assign(
+        let ret = self.exprs.assign(
             self.exprs
                 .local(defer_flag, self.types.builtin(BuiltinType::Bool), ast_span),
             self.exprs.literal(
@@ -5034,7 +5071,9 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                 ast_span,
             ),
             ast_span,
-        ))
+        );
+
+        Ok(self.exprs.tag("defer_assign", ret, ast_span))
     }
 
     fn lower_struct(
@@ -5049,10 +5088,17 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
         let field_map = self.get_struct_field_map(item)?;
         let mut uninitialized: HashSet<&'ast str> = field_map.keys().copied().collect();
 
+        let is_union = item.get_struct_like().with_backtrace(&self.diag)?.is_union;
+
         let lowered = inits
             .iter()
-            .map(|f| {
+            .enumerate()
+            .map(|(idx, f)| {
                 let _guard = self.diag.push_span(f.span);
+
+                if is_union && idx > 0 {
+                    self.diag.warn(CodeDiagnostic::UnionInitializerOverride);
+                }
 
                 uninitialized.remove(f.name);
                 match field_map.get(&f.name) {
@@ -5062,7 +5108,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                         .map(|i| (*field, i)),
                     None => Err(self
                         .diag
-                        .err(CodeErrorKind::UnresolvedItem(f.name.to_string()))),
+                        .err(CodeDiagnostic::UnresolvedItem(f.name.to_string()))),
                 }
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -5080,10 +5126,10 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             span,
         );
 
-        if !item.get_struct_like().with_backtrace(&self.diag)?.is_union && !self.tentative {
+        if !is_union && !self.tentative {
             for u in uninitialized {
                 self.diag
-                    .warn(CodeErrorKind::UninitializedField(u.to_string()));
+                    .warn(CodeDiagnostic::UninitializedField(u.to_string()));
             }
         }
 
@@ -5123,7 +5169,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
 
         let element_type = first_elem_type
             .or(element_type_hint)
-            .ok_or_else(|| self.diag.err(CodeErrorKind::TypeInferenceFailed))?;
+            .ok_or_else(|| self.diag.err(CodeDiagnostic::TypeInferenceFailed))?;
 
         self.array_of(element_type, lowered, ast_span)
     }
@@ -5146,7 +5192,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                     ast_span,
                 )
             }
-            _ => bail!(self, CodeErrorKind::CycleDetected),
+            _ => bail!(self, CodeDiagnostic::CycleDetected),
         };
 
         Ok(result.alloc_on(self.mono_ctx.ir))
@@ -5259,9 +5305,10 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             ast::ExprKind::BoundParam(self_arg, field_id, bound_type) => {
                 self.lower_bound_param(*self_arg, *field_id, *bound_type, type_hint, expr.span)
             }
+            ast::ExprKind::Tag(tag, inner) => self.lower_tag(tag, inner, type_hint, expr.span),
             ast::ExprKind::EtCetera(_)
             | ast::ExprKind::MacroInvocation(_, _)
-            | ast::ExprKind::Macro(_, _) => Err(self.diag.err(CodeErrorKind::IsAMacro)),
+            | ast::ExprKind::Macro(_, _) => Err(self.diag.err(CodeDiagnostic::IsAMacro)),
         }
     }
 }
@@ -5270,6 +5317,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
 impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
     fn get_const_string(&self, expr: ir::ExprP<'ir>) -> Result<&'ir str, AluminaError> {
         let mut evaluator = ir::const_eval::ConstEvaluator::new(
+            self.mono_ctx.global_ctx.clone(),
             self.diag.fork(),
             self.mono_ctx.malloc_bag.clone(),
             self.mono_ctx.ir,
@@ -5359,7 +5407,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             ));
         }
 
-        Err(self.diag.err(CodeErrorKind::TypeMismatch(
+        Err(self.diag.err(CodeDiagnostic::TypeMismatch(
             "array".to_string(),
             format!("{:?}", ty),
         )))
@@ -5374,7 +5422,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
 
         Err(self
             .diag
-            .err(CodeErrorKind::UserDefined(reason.to_string())))
+            .err(CodeDiagnostic::UserDefined(reason.to_string())))
     }
 
     fn compile_warn(
@@ -5385,7 +5433,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
         let reason = self.get_const_string(reason)?;
 
         self.diag
-            .warn(CodeErrorKind::UserDefined(reason.to_string()));
+            .warn(CodeDiagnostic::UserDefined(reason.to_string()));
 
         Ok(self.exprs.void(self.types.void(), ValueType::RValue, span))
     }
@@ -5398,7 +5446,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
         let reason = self.get_const_string(reason)?;
 
         self.diag
-            .note(CodeErrorKind::UserDefined(reason.to_string()));
+            .note(CodeDiagnostic::UserDefined(reason.to_string()));
 
         Ok(self.exprs.void(self.types.void(), ValueType::RValue, span))
     }
@@ -5421,6 +5469,21 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             ret_type,
             span,
         ))
+    }
+
+    fn transmute(
+        &self,
+        to: ir::TyP<'ir>,
+        arg: ir::ExprP<'ir>,
+        span: Option<Span>,
+    ) -> Result<ir::ExprP<'ir>, AluminaError> {
+        if to.assignable_from(arg.ty) {
+            Ok(arg)
+        } else {
+            Ok(self
+                .exprs
+                .codegen_intrinsic(IntrinsicValueKind::Transmute(arg), to, span))
+        }
     }
 
     fn codegen_func(
@@ -5513,7 +5576,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                 .exprs
                 .codegen_intrinsic(IntrinsicValueKind::Dangling(inner), ret_ty, span))
         } else {
-            Err(self.diag.err(CodeErrorKind::TypeMismatch(
+            Err(self.diag.err(CodeDiagnostic::TypeMismatch(
                 "pointer".to_string(),
                 format!("{:?}", ret_ty),
             )))
@@ -5529,15 +5592,17 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
     }
 
     fn const_eval(
-        &self,
+        &mut self,
         expr: ir::ExprP<'ir>,
         span: Option<Span>,
     ) -> Result<ir::ExprP<'ir>, AluminaError> {
+        let child = self.make_tentative_child();
         let mut evaluator = ir::const_eval::ConstEvaluator::new(
-            self.diag.fork(),
-            self.mono_ctx.malloc_bag.clone(),
-            self.mono_ctx.ir,
-            [],
+            child.mono_ctx.global_ctx.clone(),
+            child.diag.fork(),
+            child.mono_ctx.malloc_bag.clone(),
+            child.mono_ctx.ir,
+            child.local_types.iter().map(|(k, v)| (*k, *v)),
         );
 
         let val = evaluator.const_eval(expr)?;
@@ -5550,11 +5615,26 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
         reason: ir::ExprP<'ir>,
         span: Option<Span>,
     ) -> Result<ir::ExprP<'ir>, AluminaError> {
-        Ok(self.exprs.codegen_intrinsic(
-            IntrinsicValueKind::ConstPanic(reason),
-            self.types.builtin(BuiltinType::Never),
+        Ok(self.exprs.tag(
+            "const_only",
+            self.exprs.codegen_intrinsic(
+                IntrinsicValueKind::ConstPanic(reason),
+                self.types.builtin(BuiltinType::Never),
+                span,
+            ),
             span,
         ))
+    }
+
+    fn tag(
+        &self,
+        tag: ir::ExprP<'ir>,
+        value: ir::ExprP<'ir>,
+        span: Option<Span>,
+    ) -> Result<ir::ExprP<'ir>, AluminaError> {
+        let tag = self.get_const_string(tag)?;
+
+        Ok(self.exprs.tag(tag, value, span))
     }
 
     fn const_write(
@@ -5563,9 +5643,13 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
         warning: bool,
         span: Option<Span>,
     ) -> Result<ir::ExprP<'ir>, AluminaError> {
-        Ok(self.exprs.codegen_intrinsic(
-            IntrinsicValueKind::ConstWrite(reason, warning),
-            self.types.void(),
+        Ok(self.exprs.tag(
+            "const_only",
+            self.exprs.codegen_intrinsic(
+                IntrinsicValueKind::ConstWrite(reason, warning),
+                self.types.void(),
+                span,
+            ),
             span,
         ))
     }
@@ -5576,9 +5660,13 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
         size: ir::ExprP<'ir>,
         span: Option<Span>,
     ) -> Result<ir::ExprP<'ir>, AluminaError> {
-        Ok(self.exprs.codegen_intrinsic(
-            IntrinsicValueKind::ConstAlloc(typ, size),
-            self.types.pointer(typ, false),
+        Ok(self.exprs.tag(
+            "const_only",
+            self.exprs.codegen_intrinsic(
+                IntrinsicValueKind::ConstAlloc(typ, size),
+                self.types.pointer(typ, false),
+                span,
+            ),
             span,
         ))
     }
@@ -5588,9 +5676,13 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
         ptr: ir::ExprP<'ir>,
         span: Option<Span>,
     ) -> Result<ir::ExprP<'ir>, AluminaError> {
-        Ok(self.exprs.codegen_intrinsic(
-            IntrinsicValueKind::ConstFree(ptr),
-            self.types.void(),
+        Ok(self.exprs.tag(
+            "const_only",
+            self.exprs.codegen_intrinsic(
+                IntrinsicValueKind::ConstFree(ptr),
+                self.types.void(),
+                span,
+            ),
             span,
         ))
     }
@@ -5602,6 +5694,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
     ) -> Result<ir::ExprP<'ir>, AluminaError> {
         let child = self.make_tentative_child();
         let ret = ir::const_eval::ConstEvaluator::new(
+            child.mono_ctx.global_ctx.clone(),
             child.diag.fork(),
             child.mono_ctx.malloc_bag.clone(),
             child.mono_ctx.ir,
@@ -5688,7 +5781,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             .vtable_layouts
             .get(protocol_types)
             .ok_or_else(|| {
-                self.diag.err(CodeErrorKind::InternalError(
+                self.diag.err(CodeDiagnostic::InternalError(
                     "vtable layout not found".to_string(),
                     Backtrace::capture().into(),
                 ))
@@ -5704,7 +5797,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             // We'd need to generate a thunk for it and it's not worth the hassle.
             let function = associated_fns
                 .get(&func.name)
-                .ok_or_else(|| self.diag.err(CodeErrorKind::IndirectDyn))?;
+                .ok_or_else(|| self.diag.err(CodeDiagnostic::IndirectDyn))?;
 
             let candidate_fun = function.get_function();
 

--- a/src/alumina-boot/src/name_resolution/pass1.rs
+++ b/src/alumina-boot/src/name_resolution/pass1.rs
@@ -1,6 +1,6 @@
 use crate::ast::{AstCtx, Attribute, ItemP, MacroCtx, Span};
 use crate::common::{
-    AluminaError, ArenaAllocatable, CodeError, CodeErrorKind, IndexMap, Marker,
+    AluminaError, ArenaAllocatable, CodeDiagnostic, CodeError, IndexMap, Marker,
     WithSpanDuringParsing,
 };
 use crate::global_ctx::GlobalCtx;
@@ -192,7 +192,7 @@ impl<'ast, 'src> AluminaVisitor<'src> for FirstPassVisitor<'ast, 'src> {
 
         if node.child_by_field(FieldKind::Attributes).is_none() {
             self.global_ctx.diag().add_warning(CodeError {
-                kind: CodeErrorKind::TopLevelBlockWithoutAttributes,
+                kind: CodeDiagnostic::TopLevelBlockWithoutAttributes,
                 backtrace: vec![Marker::Span(Span::from_node(self.code.file_id(), node))],
             })
         }
@@ -338,7 +338,7 @@ impl<'ast, 'src> AluminaVisitor<'src> for FirstPassVisitor<'ast, 'src> {
                 if attributes.contains(&Attribute::TestMain)
                     && self.main_candidate.replace(item).is_some()
                 {
-                    return Err(CodeErrorKind::MultipleMainFunctions)
+                    return Err(CodeDiagnostic::MultipleMainFunctions)
                         .with_span_from(&self.scope, node);
                 }
             } else if &self.scope.path() == path
@@ -349,7 +349,8 @@ impl<'ast, 'src> AluminaVisitor<'src> for FirstPassVisitor<'ast, 'src> {
                     .any(|a| matches!(a, Attribute::LinkName(..)))
                 && self.main_candidate.replace(item).is_some()
             {
-                return Err(CodeErrorKind::MultipleMainFunctions).with_span_from(&self.scope, node);
+                return Err(CodeDiagnostic::MultipleMainFunctions)
+                    .with_span_from(&self.scope, node);
             }
         }
 

--- a/src/alumina-boot/src/parser.rs
+++ b/src/alumina-boot/src/parser.rs
@@ -1,5 +1,5 @@
 use crate::ast::Span;
-use crate::common::{AluminaError, CodeError, CodeErrorKind, FileId, Marker};
+use crate::common::{AluminaError, CodeDiagnostic, CodeError, FileId, Marker};
 
 use once_cell::unsync::OnceCell;
 
@@ -58,12 +58,12 @@ impl<'src> ParseCtx<'src> {
         for node in traverse(node.walk(), Order::Pre) {
             if node.is_error() {
                 errors.push(CodeError {
-                    kind: CodeErrorKind::ParseError(self.node_text(node).to_string()),
+                    kind: CodeDiagnostic::ParseError(self.node_text(node).to_string()),
                     backtrace: vec![Marker::Span(Span::from_node(self.file_id, node))],
                 })
             } else if node.is_missing() {
                 errors.push(CodeError {
-                    kind: CodeErrorKind::ParseErrorMissing(node.kind().to_string()),
+                    kind: CodeDiagnostic::ParseErrorMissing(node.kind().to_string()),
                     backtrace: vec![Marker::Span(Span::from_node(self.file_id, node))],
                 })
             }

--- a/src/tests/lang.alu
+++ b/src/tests/lang.alu
@@ -1,5 +1,8 @@
 //! Tests for various language features and constructs.
 
+use std::runtime::const_eval;
+use std::runtime::is_const_evaluable;
+
 #[test]
 fn test_linear_scope_shadowing_fn() {
     fn foo() -> i32 {
@@ -411,25 +414,87 @@ fn test_const_eval_uninitialized() {
 }
 
 #[test]
-fn test_const_eval_pointer_arithmetic() {
-    const VALUES: ([i32; 5], isize) = {
-        let a = [1, 2, 3, 4, 5];
-        let ptr = &a[0];
+fn test_const_pointer_operations() {
+    assert_eq!(const_eval!({ let a: [i32; 10]; &a[7] - &a[3] }), 4);
+    assert_eq!(const_eval!({ let a = "hello world"; &a[7] - &a[3] }), 4);
 
-        *ptr = -1;
-        *(ptr + 1) = -2;
-        *(ptr + 4) = -10;
+    assert!(const_eval!({ let a: [i32; 10]; &a[7] > &a[3] }));
+    assert!(const_eval!({ let a = "hello world"; &a[7] > &a[3] }));
+    assert!(const_eval!({ let a: [i32; 10]; &a[3] < &a[7] }));
+    assert!(const_eval!({ let a = "hello world"; &a[3] < &a[7] }));
+    assert!(const_eval!({ let a: [i32; 10]; &a[7] >= &a[3] }));
+    assert!(const_eval!({ let a = "hello world"; &a[7] >= &a[3] }));
+    assert!(const_eval!({ let a: [i32; 10]; &a[3] <= &a[7] }));
+    assert!(const_eval!({ let a = "hello world"; &a[3] <= &a[7] }));
+    assert!(const_eval!({ let a: [i32; 10]; &a[3] == &a[3] }));
+    assert!(const_eval!({ let a = "hello world"; &a[3] == &a[3] }));
+    assert!(const_eval!({ let a: [i32; 10]; &a[3] != &a[7] }));
+    assert!(const_eval!({ let a = "hello world"; &a[3] != &a[7] }));
 
-        (a, &a[0] - &a[5])
-    };
+    // This is a (surprising) special case for strings. Since the provenance checker
+    // compares the underlying buffer by value and not by address, we can do pointer
+    // operations across string literals that are identical.
+    assert_eq!(const_eval!({
+        let a = "hello world";
+        let b = "hello world";
+        &a[0] - &b[0]
+    }), 0);
 
+    assert!(!is_const_evaluable!({
+        let a = "bye world";
+        let b = "hello world";
+        &a[0] - &b[0]
+    }));
 
-    assert_eq!(VALUES.0, [-1, -2, 3, 4, -10]);
-    assert_eq!(VALUES.1, -5);
+    assert_eq!(const_eval!({ let a: i32; &a - &a }), 0);
+    assert!(const_eval!({ let a: i32; &a == &a }));
+    assert!(!is_const_evaluable!({ let a: i32; let b: i32; &a - &b }));
+
+    assert!(const_eval!({
+        let func = || {};
+        let a: fn() = func;
+        let b: fn() = func;
+
+        a == b
+    }));
 }
 
 #[test]
+#[allow(pure_statement)]
+#[allow(unused_variable)]
+fn test_const_pointer_punning() {
+    assert!(is_const_evaluable!({
+        let a = [1, 2, 3];
+        let b = (&a[0] as &u8);
+    }));
 
+    assert!(!is_const_evaluable!({
+        let a = [1, 2, 3];
+        let b = (&a[0] as &u8) + 1;
+    }));
+
+    assert!(!is_const_evaluable!({
+        let a = [1, 2, 3];
+        let b = (&a[0] as &u8) - (&a[0] as &u8);
+    }));
+
+    // Comparison through incompatible pointer type is allowed, just dereferencing
+    // and arithmetic are not
+    assert!(is_const_evaluable!({
+        let a = [1, 2, 3];
+        let b = (&a[0] as &u8) == (&a[0] as &u8);
+    }));
+
+    assert!(is_const_evaluable!({
+        let a = [1, 2, 3];
+        let b = (&a[0] as &u8) < (&a[0] as &u8);
+    }));
+
+    assert!(is_const_evaluable!({
+        let a = [1, 2, 3];
+        let b = (&a[0] as &u8 as &i32) + 1;
+    }));
+}
 
 #[test]
 fn test_const_eval_library_functions() {

--- a/sysroot/std.alu
+++ b/sysroot/std.alu
@@ -83,7 +83,10 @@ macro compile_note($reason) {
 /// assert!(1 + 1 == 3); // panics
 /// ```
 macro assert($cond) {
-    internal::assert_impl(file!(), line!(), column!(), $cond);
+    #[cfg(debug)]
+    internal::assert(file!(), line!(), column!(), stringify!($cond), $cond);
+    #[cfg(not(debug))]
+    internal::assert(file!(), line!(), column!(), $cond);
 }
 
 /// Panics if `lhs` and `rhs` are not equal.
@@ -179,9 +182,9 @@ macro unreachable() {
 /// ```
 macro assume($cond) {
     #[cfg(debug)]
-    internal::assert_impl(file!(), line!(), column!(), $cond);
+    assert!($cond);
     #[cfg(not(debug))]
-    internal::assume_impl($cond);
+    internal::assume($cond);
 }
 
 /// Hint to the compiler that a particular boolean expression is likely true.
@@ -236,7 +239,40 @@ macro unlikely($cond) {
 #[builtin] macro file() {  }
 
 /// Returns the value of an environment variable during compilation.
+///
+/// Not to be confused with [std::process::env], which can be used to access environment
+/// variables at runtime.
+///
+/// ## Example
+/// ```
+/// use std::env;
+///
+/// let build_host = env!("HOSTNAME");
+///
+/// println!("This program was built on {}", build_host);
+/// ```
 #[builtin] macro env($s) {  }
+
+/// Returns the value of a configuration flag during compilation.
+///
+/// This can be used as an alternative to `#[cfg]` attributes. The difference is that
+/// `cfg!` can be used in any expression position, while `#[cfg]` can only be used on
+/// statements and items.
+///
+/// ## Example
+/// ```
+/// use std::cfg;
+/// use std::time::Duration;
+/// use std::thread::sleep;
+///
+/// when cfg!("debug") {
+///     sleep(Duration::from_millis(100));
+///     println!("program was built in debug mode, that's why it's so slow ;)");
+/// } else {
+///     println!("program was built in release mode and is blazing fast!");
+/// }
+/// ```
+#[builtin] macro cfg($s) {  }
 
 /// Reads a file during compilation and returns its contents as a string slice.
 ///
@@ -281,7 +317,7 @@ macro unlikely($cond) {
 /// ## Example
 /// ```
 /// let a = 1;
-/// // Prints "[<filename>:<line>:<column>] 2"
+/// // Prints "[<filename>:<line>:<column>] a + 1 = 2"
 /// let b = 2 * dbg!(a + 1);
 ///
 /// assert_eq!(b, 4);
@@ -290,10 +326,11 @@ macro dbg($value) {
     let val = $value;
     let f = panicking::internal::PanicFormatter {};
     fmt::writeln!(&f,
-        "[{}:{}:{}] {}",
+        "[{}:{}:{}] {} = {}",
         file!(),
         line!(),
         column!(),
+        stringify!($value),
         val
     ).unwrap();
     val
@@ -305,23 +342,90 @@ mod internal {
     // error message if the argument is Formattable.
 
     #[inline(always)]
-    fn assume_impl(cond: bool) {
+    fn assume(cond: bool) {
         #[allow(constant_condition)]
         if !cond {
             std::intrinsics::unreachable();
         }
     }
 
+    #[cfg(not(debug))]
     #[inline(always)]
-    fn assert_impl(file: &[u8], line: i32, column: i32, cond: bool) {
+    fn assert(file: &[u8], line: i32, column: i32, cond: bool) {
+        #[cold]
+        #[inline(never)]
+        fn panic_assert(file: &[u8], line: i32, column: i32) -> ! {
+            use panicking::internal::panic_impl;
+
+            panic_impl(
+                file, line, column,
+                &fmt::format_args!(
+                    fmt::internal::dyn_format_args,
+                    "assertion failed"
+                )
+            )
+        }
+
         #[allow(constant_condition)]
         if !cond {
             panic_assert(file, line, column);
         }
     }
 
+    #[cfg(debug)]
+    #[inline(always)]
+    fn assert(file: &[u8], line: i32, column: i32, expr: &[u8], cond: bool) {
+        #[cold]
+        #[inline(never)]
+        fn panic_assert(file: &[u8], line: i32, expr: &[u8], column: i32) -> ! {
+            use panicking::internal::panic_impl;
+
+            panic_impl(
+                file, line, column,
+                &fmt::format_args!(
+                    fmt::internal::dyn_format_args,
+                    "assertion `{}` failed",
+                    expr
+                )
+            )
+        }
+
+        #[allow(constant_condition)]
+        if !cond {
+            panic_assert(file, line, expr, column);
+        }
+    }
+
     #[inline(always)]
     fn assert_eq<T>(file: &[u8], line: i32, column: i32, lhs: T, rhs: T)  {
+        #[cold]
+        #[inline(never)]
+        fn panic_assert_eq(file: &[u8], line: i32, column: i32, lhs: T, rhs: T) -> ! {
+            use panicking::internal::panic_impl;
+            use fmt::Formattable;
+
+            when lhs is Formattable<T, panicking::internal::PanicFormatter> {
+                panic_impl(
+                    file, line, column,
+                    &fmt::format_args!(
+                        fmt::internal::dyn_format_args,
+                        "assertion failed ({} != {}))",
+                        lhs,
+                        rhs
+                    )
+                )
+            }
+            else {
+                panic_impl(
+                    file, line, column,
+                    &fmt::format_args!(
+                        fmt::internal::dyn_format_args,
+                        "assertion failed (does not equal))",
+                    )
+                )
+            }
+        }
+
         #[allow(constant_condition)]
         if !(lhs == rhs) {
             panic_assert_eq(file, line, column, lhs, rhs)
@@ -330,79 +434,37 @@ mod internal {
 
     #[inline(always)]
     fn assert_ne<T>(file: &[u8], line: i32, column: i32, lhs: T, rhs: T)  {
+        #[cold]
+        #[no_inline]
+        fn panic_assert_ne(file: &[u8], line: i32, column: i32, lhs: T, rhs: T) -> ! {
+            use panicking::internal::panic_impl;
+            use fmt::Formattable;
+
+            when lhs is Formattable<T, panicking::internal::PanicFormatter> {
+                panic_impl(
+                    file, line, column,
+                    &fmt::format_args!(
+                        fmt::internal::dyn_format_args,
+                        "assertion failed ({} == {}))",
+                        lhs,
+                        rhs
+                    )
+                )
+            }
+            else {
+                panic_impl(
+                    file, line, column,
+                    &fmt::format_args!(
+                        fmt::internal::dyn_format_args,
+                        "assertion failed (equals))",
+                    )
+                )
+            }
+        }
+
         #[allow(constant_condition)]
         if lhs == rhs {
             panic_assert_ne(file, line, column, lhs, rhs)
-        }
-    }
-
-    #[cold]
-    #[inline(never)]
-    fn panic_assert(file: &[u8], line: i32, column: i32) -> ! {
-        use panicking::internal::panic_impl;
-
-        panic_impl(
-            file, line, column,
-            &fmt::format_args!(
-                fmt::internal::dyn_format_args,
-                "assertion failed"
-            )
-        )
-    }
-
-    #[cold]
-    #[inline(never)]
-    fn panic_assert_eq<T>(file: &[u8], line: i32, column: i32, lhs: T, rhs: T) -> ! {
-        use panicking::internal::panic_impl;
-        use fmt::Formattable;
-
-        when lhs is Formattable<T, panicking::internal::PanicFormatter> {
-            panic_impl(
-                file, line, column,
-                &fmt::format_args!(
-                    fmt::internal::dyn_format_args,
-                    "assertion failed ({} != {}))",
-                    lhs,
-                    rhs
-                )
-            )
-        }
-        else {
-            panic_impl(
-                file, line, column,
-                &fmt::format_args!(
-                    fmt::internal::dyn_format_args,
-                    "assertion failed (does not equal))",
-                )
-            )
-        }
-    }
-
-    #[cold]
-    #[no_inline]
-    fn panic_assert_ne<T>(file: &[u8], line: i32, column: i32, lhs: T, rhs: T) -> ! {
-        use panicking::internal::panic_impl;
-        use fmt::Formattable;
-
-        when lhs is Formattable<T, panicking::internal::PanicFormatter> {
-            panic_impl(
-                file, line, column,
-                &fmt::format_args!(
-                    fmt::internal::dyn_format_args,
-                    "assertion failed ({} == {}))",
-                    lhs,
-                    rhs
-                )
-            )
-        }
-        else {
-            panic_impl(
-                file, line, column,
-                &fmt::format_args!(
-                    fmt::internal::dyn_format_args,
-                    "assertion failed (equals))",
-                )
-            )
         }
     }
 

--- a/sysroot/std/builtins.alu
+++ b/sysroot/std/builtins.alu
@@ -1516,25 +1516,37 @@ mod internal {
         /// Adds two numbers, wrapping around at the boundary of the type.
         #[inline]
         fn wrapping_add(lhs: Self, rhs: Self) -> Self {
-            let ret: Self;
-            intrinsics::codegen_func::<bool>("__builtin_add_overflow", lhs, rhs, &ret);
-            ret
+            if runtime::in_const_context() {
+                ((lhs as unsigned_of<Self>) + (rhs as unsigned_of<Self>)) as Self
+            } else {
+                let ret: Self;
+                intrinsics::codegen_func::<bool>("__builtin_add_overflow", lhs, rhs, &ret);
+                ret
+            }
         }
 
         /// Subtracts two numbers, wrapping around at the boundary of the type.
         #[inline]
         fn wrapping_sub(lhs: Self, rhs: Self) -> Self {
-            let ret: Self;
-            intrinsics::codegen_func::<bool>("__builtin_sub_overflow", lhs, rhs, &ret);
-            ret
+            if runtime::in_const_context() {
+                ((lhs as unsigned_of<Self>) - (rhs as unsigned_of<Self>)) as Self
+            } else {
+                let ret: Self;
+                intrinsics::codegen_func::<bool>("__builtin_sub_overflow", lhs, rhs, &ret);
+                ret
+            }
         }
 
         /// Multiplies two numbers, wrapping around at the boundary of the type.
         #[inline]
         fn wrapping_mul(lhs: Self, rhs: Self) -> Self {
-            let ret: Self;
-            intrinsics::codegen_func::<bool>("__builtin_mul_overflow", lhs, rhs, &ret);
-            ret
+            if runtime::in_const_context() {
+                ((lhs as unsigned_of<Self>) * (rhs as unsigned_of<Self>)) as Self
+            } else {
+                let ret: Self;
+                intrinsics::codegen_func::<bool>("__builtin_mul_overflow", lhs, rhs, &ret);
+                ret
+            }
         }
 
         /// Divides two numbers, wrapping around at the boundary of the type.

--- a/sysroot/std/fmt/ryu/pretty/mantissa.alu
+++ b/sysroot/std/fmt/ryu/pretty/mantissa.alu
@@ -14,6 +14,7 @@ fn write_mantissa_long(output: u64, result: &mut u8) {
         let c1 = (c / 100) << 1;
         let d0 = (d % 100) << 1;
         let d1 = (d / 100) << 1;
+
         mem::copy_nonoverlapping(
             DIGIT_TABLE.as_ptr() + (c0 as isize),
             result - 2,

--- a/sysroot/std/intrinsics.alu
+++ b/sysroot/std/intrinsics.alu
@@ -3,9 +3,11 @@
 //! Functions in this module are not intended for general use, and are usually called by
 //! wrapper functions in the standard library (e.g. [mem::size_of] and [std::unreachable]).
 //!
-//! Intrinsic functions are also not first-class citizens. You cannot take a reference to
-//! one, or pass it as an argument to another function. Also, intrinsic functions do not
-//! participate in type inference.
+//! Intrinsic functions are not first-class citizens. You cannot take a reference to
+//! one, or pass it as an argument to another function. The intrinsic call signature is not
+//! strictly enforced (pass as many arguments as you want, they will be ignored, the intrinsic
+//! may return a value of different type, etc.). Needless to say, intrinsics do not participate
+//! in type inference.
 
 /// Fail the compilation process with a human-readable message.
 ///
@@ -98,12 +100,12 @@ extern "intrinsic" fn in_const_context() -> bool;
 /// Returns `true` if the expression is evaluable at compile-time.
 ///
 /// Use [runtime::is_const_evaluable] instead.
-extern "intrinsic" fn is_const_evaluable(...) -> bool;
+extern "intrinsic" fn is_const_evaluable<T>(expr: T) -> bool;
 
 /// Forces the argument to be evaluated at compile-time.
 ///
 /// Use [runtime::const_eval] instead.
-extern "intrinsic" fn const_eval(...);
+extern "intrinsic" fn const_eval<T>(expr: T) -> T;
 
 /// Panics during constant evaluation (aborts compilation).
 ///
@@ -135,6 +137,32 @@ extern "intrinsic" fn const_alloc<T>(size: usize) -> &mut T;
 ///
 /// Use [mem::slice::free] in const context instead.
 extern "intrinsic" fn const_free<T>(ptr: &mut T);
+
+/// Transmute a value from one type to another.
+///
+/// Use [util::transmute] instead.
+extern "intrinsic" fn transmute<T1, T2>(val: T1) -> T2;
+
+/// Identity function.
+///
+/// Adds a tag to the IR subtree. This has no effect on the generated code, but is generally preserved
+/// accross passes until codegen. Tags control certain aspects of const evaluation and compiler
+/// diagnostics. They are not meant to be used by user code.
+///
+/// Tags are currently added when desugaring certain language constructs, such as `for` loops and `defer`
+/// expressions.
+///
+/// The type, constness and value-kind of the tagged expression are preserved.
+/// ```
+/// let x = 0;
+/// std::intrinsics::tag("foo", x) += 1; // this is valid
+///
+/// assert_eq!(x, 1);
+/// ```
+///
+/// No user-facing equivalent.
+extern "intrinsic" fn tag<T>(tag: &[u8], val: T) -> T;
+
 
 #[cfg(boot)]
 {

--- a/sysroot/std/io.alu
+++ b/sysroot/std/io.alu
@@ -557,25 +557,25 @@ impl BufferedWriter<W: Writable<W>> {
         }
     }
 
-    #[cold]
-    #[inline(never)]
-    fn write_full(self: &mut BufferedWriter<W>, buf: &[u8]) -> Result<usize> {
-        if buf.len() > self.buf.len() - self.pos {
-            self._flush_buffer()?;
-        }
-
-        if buf.len() >= self.buf.len()  {
-            // Bypass the buffer if we need to write more than buffer size
-            self.inner.write(buf)
-        } else {
-            self._write_to_buffer(buf);
-            Result::ok(buf.len())
-        }
-    }
-
     /// @ Writable::write
     #[inline]
     fn write(self: &mut BufferedWriter<W>, buf: &[u8]) -> Result<usize> {
+        #[cold]
+        #[inline(never)]
+        fn write_full(self: &mut BufferedWriter<W>, buf: &[u8]) -> Result<usize> {
+            if buf.len() > self.buf.len() - self.pos {
+                self._flush_buffer()?;
+            }
+
+            if buf.len() >= self.buf.len()  {
+                // Bypass the buffer if we need to write more than buffer size
+                self.inner.write(buf)
+            } else {
+                self._write_to_buffer(buf);
+                Result::ok(buf.len())
+            }
+        }
+
         if buf.len() < self.buf.len() - self.pos {
             self._write_to_buffer(buf);
             Result::ok(buf.len())
@@ -587,11 +587,27 @@ impl BufferedWriter<W: Writable<W>> {
     /// @ Writable::write_all
     #[inline]
     fn write_all(self: &mut BufferedWriter<W>, buf: &[u8]) -> Result<()> {
+        #[cold]
+        #[inline(never)]
+        fn write_all_full(self: &mut BufferedWriter<W>, buf: &[u8]) -> Result<()> {
+            if buf.len() > self.buf.len() - self.pos {
+                self._flush_buffer()?;
+            }
+
+            if buf.len() >= self.buf.len() {
+                // Bypass the buffer if we need to write more than buffer size
+                self.inner.write_all(buf)
+            } else {
+                self._write_to_buffer(buf);
+                Result::ok(())
+            }
+        }
+
         if buf.len() < self.buf.len() - self.pos {
             self._write_to_buffer(buf);
             Result::ok(())
         } else {
-            self._write_all_full(buf)
+            self.write_all_full(buf)
         }
     }
 
@@ -603,12 +619,15 @@ impl BufferedWriter<W: Writable<W>> {
 
     #[inline]
     fn _write_to_buffer(self: &mut BufferedWriter<W>, buf: &[u8]) {
-        if buf.len() > 0 {
-            // This guard is technically redundant, but to avoid the debug assertion
-            // when indexing past the end of the buffer with 0-length writes.
-            buf.copy_to_nonoverlapping(&self.buf[self.pos]);
-            self.pos += buf.len();
+        // This guard is technically redundant, but to avoid the debug assertion
+        // when indexing past the end of the buffer with 0-length writes.
+        #[cfg(any(debug, bounds_checks))]
+        if buf.len() == 0 {
+            return;
         }
+
+        buf.copy_to_nonoverlapping(&self.buf[self.pos]);
+        self.pos += buf.len();
     }
 
     fn _flush_buffer(self: &mut BufferedWriter<W>) -> Result<()> {
@@ -619,22 +638,6 @@ impl BufferedWriter<W: Writable<W>> {
         self.pos = 0;
 
         Result::ok(())
-    }
-
-    #[cold]
-    #[inline(never)]
-    fn _write_all_full(self: &mut BufferedWriter<W>, buf: &[u8]) -> Result<()> {
-        if buf.len() > self.buf.len() - self.pos {
-            self._flush_buffer()?;
-        }
-
-        if buf.len() >= self.buf.len() {
-            // Bypass the buffer if we need to write more than buffer size
-            self.inner.write_all(buf)
-        } else {
-            self._write_to_buffer(buf);
-            Result::ok(())
-        }
     }
 
     /// @ std::mem::Freeable::free
@@ -667,18 +670,67 @@ const DEFAULT_BUFFER_SIZE: usize = 8192;
 // Extension methods
 
 /// Returns an adapter for a stream that returns EOF after `limit` bytes have been read.
+///
+/// ## Example
+/// ```
+/// use std::io::{SliceReader, take};
+/// use std::string::StringBuf;
+///
+/// let reader = SliceReader::new("Hello, world!");
+///
+/// let buf: StringBuf = StringBuf::new();
+/// defer buf.free();
+///
+/// reader.take(5).read_to_end(&buf).unwrap();
+///
+/// assert_eq!(buf[..] as &[u8], "Hello");
+/// ```
 fn take<R: Readable<R>>(self: &mut R, limit: u64) -> TakeAdapter<R> {
     TakeAdapter::new(self, limit)
 }
 
 /// Chains the two streams together
+///
+/// The resulting stream will first read all bytes from `self`, then all bytes from `other`.
+///
+/// ## Example
+/// ```
+/// use std::io::{SliceReader, chain};
+/// use std::string::StringBuf;
+///
+/// let reader1 = SliceReader::new("Hello, ");
+/// let reader2 = SliceReader::new("world!");
+///
+/// let buf: StringBuf = StringBuf::new();
+/// defer buf.free();
+///
+/// reader1.chain(&reader2).read_to_end(&buf).unwrap();
+///
+/// assert_eq!(buf[..] as &[u8], "Hello, world!");
+/// ```
 fn chain<R1: Readable<R1>, R2: Readable<R2>>(self: &mut R1, other: &mut R2) -> ChainAdapter<R1, R2> {
     ChainAdapter::new(self, other)
 }
 
 /// Copy the entire stream `src` into `dst`
 ///
-/// Internally allocates a buffer with the size of [DEFAULT_BUFFER_SIZE].
+/// Internally allocates a buffer with the size of [DEFAULT_BUFFER_SIZE]. If you want to use a
+/// custom buffer, use [copy_using].
+///
+/// ## Example
+/// ```
+/// use std::io::{copy, SliceReader, StringWriter};
+/// use std::string::StringBuf;
+///
+/// let str: StringBuf = StringBuf::new();
+/// defer str.free();
+///
+/// let writer = StringWriter::new(&str);
+/// let reader = SliceReader::new("Hello, world!");
+///
+/// copy(&reader, &writer).unwrap();
+/// assert_eq!(str[..] as &[u8], "Hello, world!");
+/// ```
 fn copy<S: Readable<S>, D: Writable<D>>(src: &mut S, dst: &mut D) -> Result<u64> {
     let buf = mem::slice::alloc::<u8>(DEFAULT_BUFFER_SIZE);
     defer buf.free();

--- a/sysroot/std/mem.alu
+++ b/sysroot/std/mem.alu
@@ -304,6 +304,58 @@ impl slice {
         }
     }
 
+    /// Returns a subslice of the given slice.
+    ///
+    /// This is a safe version of range indexing (`slice[a..b]`, `slice[a..]`, ...). Instead
+    /// of panicking or causing UB when the range is out of bounds, this function returns
+    /// `Option::none()`.
+    ///
+    /// ## Example
+    /// ```
+    /// let hw = "Hello, world";
+    /// assert_eq!(hw.get_range(..5usize), Option::some("Hello"));
+    /// assert_eq!(hw.get_range(7usize..), Option::some("world"));
+    /// assert_eq!(hw.get_range(7usize..12), Option::some("world"));
+    /// assert_eq!(hw.get_range(7usize..13), Option::none());
+    /// ```
+    fn get_range<Ptr: Pointer, T: builtins::RangeOf<usize>>(self: slice<Ptr>, range: T) -> Option<slice<Ptr>> {
+        when range is range::Range<usize> {
+            if (range.lower <= range.upper && range.upper <= self.len()) {
+                Option::some(slice::from_raw::<Ptr>(self._ptr + range.lower, range.upper - range.lower))
+            } else {
+                Option::none()
+            }
+        } else when range is range::RangeInclusive<usize> {
+            if (range.lower <= range.upper && range.upper < self.len()) {
+                Option::some(slice::from_raw::<Ptr>(self._ptr + range.lower, range.upper - range.lower + 1))
+            } else {
+                Option::none()
+            }
+        } else when range is range::RangeTo<usize> {
+            if (range.upper <= self.len()) {
+                Option::some(slice::from_raw::<Ptr>(self._ptr, range.upper))
+            } else {
+                Option::none()
+            }
+        } else when range is range::RangeToInclusive<usize> {
+            if (range.upper < self.len()) {
+                Option::some(slice::from_raw::<Ptr>(self._ptr, range.upper + 1))
+            } else {
+                Option::none()
+            }
+        } else when range is range::RangeFrom<usize> {
+            if (range.lower <= self.len()) {
+                Option::some(slice::from_raw::<Ptr>(self._ptr + range.lower, self.len() - range.lower))
+            } else {
+                Option::none()
+            }
+        } else when range is range::RangeFull<usize> {
+            Option::some(self)
+        } else {
+            compile_fail!("unsupported range type");
+        }
+    }
+
     /// Copy a slice into a fixed-size array.
     ///
     /// The length of the result array must exactly match the length of the slice.

--- a/sysroot/std/option.alu
+++ b/sysroot/std/option.alu
@@ -124,7 +124,7 @@ impl Option<T> {
         !self._is_some
     }
 
-    /// Returns a value, if present, panic otherwise.
+    /// Returns a value, if present, panics otherwise.
     ///
     /// ## Examples
     /// ```
@@ -137,10 +137,16 @@ impl Option<T> {
     /// ```
     #[inline(always)]
     fn unwrap(self: Option<T>) -> T {
+        #[cold]
+        #[inline(never)]
+        fn unwrap_panic() -> ! {
+            panic!("called `Option::unwrap()` on a `None` value")
+        }
+
         if self.is_some() {
             self._inner
         } else {
-            internal::unwrap_panic();
+            unwrap_panic();
         }
     }
 
@@ -523,15 +529,6 @@ impl Option {
 
     mixin<T: Equatable<T>> Equatable<Option<T>>;
     mixin<T: Comparable<T>> Comparable<Option<T>>;
-}
-
-#[docs(no_index)]
-mod internal {
-    #[cold]
-    #[inline(never)]
-    fn unwrap_panic() -> ! {
-        panic!("called `Option::unwrap()` on a `None` value")
-    }
 }
 
 #[cfg(all(test, test_std))]

--- a/sysroot/std/result.alu
+++ b/sysroot/std/result.alu
@@ -205,12 +205,24 @@ impl Result<T, E> {
     ///
     /// r.unwrap(); // panics
     /// ```
-    #[inline]
+    #[inline(always)]
     fn unwrap(self: Result<T, E>) -> T {
+        #[cold]
+        #[inline(never)]
+        fn unwrap_panic_err(err: E) -> ! {
+            use fmt::Formattable;
+
+            when err is Formattable<E, panicking::internal::PanicFormatter> {
+                panic!("unwrap on an err value: {}", err)
+            } else {
+                panic!("unwrap on an err value")
+            }
+        }
+
         if self.is_ok() {
             self._inner.ok
         } else {
-            internal::unwrap_panic_err(self._inner.err);
+            unwrap_panic_err(self._inner.err);
         }
     }
 
@@ -227,12 +239,24 @@ impl Result<T, E> {
     ///
     /// r.unwrap_err(); // panics
     /// ```
-    #[inline]
+    #[inline(always)]
     fn unwrap_err(self: Result<T, E>) -> E {
+        #[cold]
+        #[inline(never)]
+        fn unwrap_panic_ok(ok: T) -> ! {
+            use fmt::Formattable;
+
+            when ok is Formattable<T, panicking::internal::PanicFormatter> {
+                panic!("unwrap on an ok value: {}", ok)
+            } else {
+                panic!("unwrap on an ok value")
+            }
+        }
+
         if self.is_err() {
             self._inner.err
         } else {
-            internal::unwrap_panic_ok(self._inner.ok);
+            unwrap_panic_ok(self._inner.ok);
         }
     }
 
@@ -411,29 +435,4 @@ impl Result {
     }
 
     mixin<T: Equatable<T>, E: Equatable<E>> Equatable<Result<T, E>>;
-}
-
-#[docs(no_index)]
-mod internal {
-    use fmt::{write, Formatter, Formattable};
-
-    #[cold]
-    #[inline(never)]
-    fn unwrap_panic_err<E>(err: E) -> ! {
-        when err is Formattable<E, panicking::internal::PanicFormatter> {
-            panic!("unwrap on an err value: {}", err)
-        } else {
-            panic!("unwrap on an err value")
-        }
-    }
-
-    #[cold]
-    #[inline(never)]
-    fn unwrap_panic_ok<T>(ok: T) -> ! {
-        when ok is Formattable<T, panicking::internal::PanicFormatter> {
-            panic!("unwrap on an ok value: {}", ok)
-        } else {
-            panic!("unwrap on an ok value")
-        }
-    }
 }

--- a/sysroot/std/sync.alu
+++ b/sysroot/std/sync.alu
@@ -84,19 +84,31 @@ impl Atomic<T: Primitive + !ZeroSized> {
     /// Loads a value from the atomic variable.
     #[inline(ir)]
     fn load(self: &Atomic<T>, ordering: Ordering) -> T {
-        intrinsics::codegen_func::<T>("__atomic_load_n", &self._inner, ordering as libc::c_int)
+        if runtime::in_const_context() {
+            self._inner
+        } else {
+            intrinsics::codegen_func::<T>("__atomic_load_n", &self._inner, ordering as libc::c_int)
+        }
     }
 
     /// Stores a value into the atomic variable.
     #[inline(ir)]
     fn store(self: &mut Atomic<T>, value: T, ordering: Ordering) {
-        intrinsics::codegen_func::<void>("__atomic_store_n", &self._inner, value, ordering as libc::c_int)
+        if runtime::in_const_context() {
+            self._inner = value;
+        } else {
+            intrinsics::codegen_func::<void>("__atomic_store_n", &self._inner, value, ordering as libc::c_int)
+        }
     }
 
     /// Stores a value into the atomic variable, atomically returning the old value.
     #[inline(ir)]
     fn exchange(self: &mut Atomic<T>, value: T, ordering: Ordering) -> T {
-        intrinsics::codegen_func::<T>("__atomic_exchange_n", &self._inner, value, ordering as libc::c_int)
+        if runtime::in_const_context() {
+            mem::replace(&self._inner, value)
+        } else {
+            intrinsics::codegen_func::<T>("__atomic_exchange_n", &self._inner, value, ordering as libc::c_int)
+        }
     }
 
     /// Atomically compares the value in the atomic variable to `expected` and, if they are equal,
@@ -139,18 +151,27 @@ impl Atomic<T: Primitive + !ZeroSized> {
         success_ordering: Ordering,
         failure_ordering: Ordering
     ) -> Result<T, T> {
-        if intrinsics::codegen_func::<bool>(
-            "__atomic_compare_exchange_n",
-            &self._inner,
-            &expected,
-            desired,
-            false,
-            success_ordering as libc::c_int,
-            failure_ordering as libc::c_int
-        ) {
-            Result::ok(expected)
+        if runtime::in_const_context() {
+            if self._inner == expected {
+                self._inner = desired;
+                Result::ok(expected)
+            } else {
+                Result::err(self._inner)
+            }
         } else {
-            Result::err(expected)
+            if intrinsics::codegen_func::<bool>(
+                "__atomic_compare_exchange_n",
+                &self._inner,
+                &expected,
+                desired,
+                false,
+                success_ordering as libc::c_int,
+                failure_ordering as libc::c_int
+            ) {
+                Result::ok(expected)
+            } else {
+                Result::err(expected)
+            }
         }
     }
 
@@ -169,18 +190,22 @@ impl Atomic<T: Primitive + !ZeroSized> {
         success_ordering: Ordering,
         failure_ordering: Ordering
     ) -> Result<T, T> {
-        if intrinsics::codegen_func::<bool>(
-            "__atomic_compare_exchange_n",
-            &self._inner,
-            &expected,
-            desired,
-            true,
-            success_ordering as libc::c_int,
-            failure_ordering as libc::c_int
-        ) {
-            Result::ok(expected)
+        if runtime::in_const_context() {
+            self.compare_exchange(expected, desired, success_ordering, failure_ordering)
         } else {
-            Result::err(expected)
+            if intrinsics::codegen_func::<bool>(
+                "__atomic_compare_exchange_n",
+                &self._inner,
+                &expected,
+                desired,
+                true,
+                success_ordering as libc::c_int,
+                failure_ordering as libc::c_int
+            ) {
+                Result::ok(expected)
+            } else {
+                Result::err(expected)
+            }
         }
     }
 
@@ -250,44 +275,70 @@ impl Atomic<T: Integer> {
     /// Atomically adds `value` to the atomic variable and returns the old value.
     #[inline(ir)]
     fn fetch_add(self: &mut Atomic<T>, value: T, ordering: Ordering) -> T {
-        intrinsics::codegen_func::<T>("__atomic_fetch_add", &self._inner, value, ordering as libc::c_int)
+        if runtime::in_const_context() {
+            internal::const_atomic_update(self, value, |x: T, y: T| -> T { x + y })
+        } else {
+            intrinsics::codegen_func::<T>("__atomic_fetch_add", &self._inner, value, ordering as libc::c_int)
+        }
     }
 
     /// Atomically subtracts `value` from the atomic variable and returns the old value.
     #[inline(ir)]
     fn fetch_sub(self: &mut Atomic<T>, value: T, ordering: Ordering) -> T {
-        intrinsics::codegen_func::<T>("__atomic_fetch_sub", &self._inner, value, ordering as libc::c_int)
+        if runtime::in_const_context() {
+            internal::const_atomic_update(self, value, |x: T, y: T| -> T { x - y })
+        } else {
+            intrinsics::codegen_func::<T>("__atomic_fetch_sub", &self._inner, value, ordering as libc::c_int)
+        }
     }
 
     /// Atomically performs `*self &= value` and returns the old value.
     #[inline(ir)]
     fn fetch_and(self: &mut Atomic<T>, value: T, ordering: Ordering) -> T {
-        intrinsics::codegen_func::<T>("__atomic_fetch_and", &self._inner, value, ordering as libc::c_int)
+        if runtime::in_const_context() {
+            internal::const_atomic_update(self, value, |x: T, y: T| -> T { x & y })
+        } else {
+            intrinsics::codegen_func::<T>("__atomic_fetch_and", &self._inner, value, ordering as libc::c_int)
+        }
     }
 
     /// Atomically performs `*self |= value` and returns the old value.
     #[inline(ir)]
     fn fetch_or(self: &mut Atomic<T>, value: T, ordering: Ordering) -> T {
-        intrinsics::codegen_func::<T>("__atomic_fetch_or", &self._inner, value, ordering as libc::c_int)
+        if runtime::in_const_context() {
+            internal::const_atomic_update(self, value, |x: T, y: T| -> T { x | y })
+        } else {
+            intrinsics::codegen_func::<T>("__atomic_fetch_or", &self._inner, value, ordering as libc::c_int)
+        }
     }
 
     /// Atomically performs `*self ^= value` and returns the old value.
     #[inline(ir)]
     fn fetch_xor(self: &mut Atomic<T>, value: T, ordering: Ordering) -> T {
-        intrinsics::codegen_func::<T>("__atomic_fetch_xor", &self._inner, value, ordering as libc::c_int)
+        if runtime::in_const_context() {
+            internal::const_atomic_update(self, value, |x: T, y: T| -> T { x ^ y })
+        } else {
+            intrinsics::codegen_func::<T>("__atomic_fetch_xor", &self._inner, value, ordering as libc::c_int)
+        }
     }
 
     /// Atomically performs `*self = ~(*self & value)` and returns the old value.
     #[inline(ir)]
     fn fetch_nand(self: &mut Atomic<T>, value: T, ordering: Ordering) -> T {
-        intrinsics::codegen_func::<T>("__atomic_fetch_nand", &self._inner, value, ordering as libc::c_int)
+        if runtime::in_const_context() {
+            internal::const_atomic_update(self, value, |x: T, y: T| -> T { ~(x & y) })
+        } else {
+            intrinsics::codegen_func::<T>("__atomic_fetch_nand", &self._inner, value, ordering as libc::c_int)
+        }
     }
 }
 
 /// Memory barrier
 #[inline(ir)]
 fn fence(ordering: Ordering) {
-    intrinsics::codegen_func::<void>("__atomic_thread_fence", ordering as libc::c_int)
+    if !runtime::in_const_context() {
+        intrinsics::codegen_func::<void>("__atomic_thread_fence", ordering as libc::c_int)
+    }
 }
 
 /// Compiler-only memory barrier
@@ -296,7 +347,9 @@ fn fence(ordering: Ordering) {
 /// memory access ordering, but does not prevent hardware reordering.
 #[inline(ir)]
 fn compiler_fence(ordering: Ordering) {
-    intrinsics::codegen_func::<void>("__atomic_signal_fence", ordering as libc::c_int)
+    if !runtime::in_const_context() {
+        intrinsics::codegen_func::<void>("__atomic_thread_fence", ordering as libc::c_int)
+    }
 }
 
 /// A hint to the CPU that we are spinning
@@ -315,14 +368,16 @@ fn compiler_fence(ordering: Ordering) {
 /// ```
 #[inline(ir)]
 fn spin_loop() {
-    #[cfg(target_arch = "x86")]
-    std::intrinsics::asm("pause");
-    #[cfg(target_arch = "x86_64")]
-    std::intrinsics::asm("pause");
-    #[cfg(target_arch = "arm")]
-    std::intrinsics::asm("yield");
-    #[cfg(target_arch = "aarch64")]
-    std::intrinsics::asm("isb sy");
+    if !runtime::in_const_context() {
+        #[cfg(target_arch = "x86")]
+        std::intrinsics::asm("pause");
+        #[cfg(target_arch = "x86_64")]
+        std::intrinsics::asm("pause");
+        #[cfg(target_arch = "arm")]
+        std::intrinsics::asm("yield");
+        #[cfg(target_arch = "aarch64")]
+        std::intrinsics::asm("isb sy");
+    }
 }
 
 /// Protocol for types implementing mutex-like semantics.
@@ -855,6 +910,14 @@ mod internal {
         thread: thread::Thread,
         signaled: Atomic<bool>,
         next: &mut EventWaiter,
+    }
+
+    // Used only in the const context, extracted as a function so the main atomic operation
+    // can be IR-inlined
+    fn const_atomic_update<T>(a: &mut Atomic<T>, b: T, op: fn(T, T) -> T) -> T {
+        let old = a._inner;
+        a._inner = op(old, b);
+        old
     }
 }
 

--- a/sysroot/std/util.alu
+++ b/sysroot/std/util.alu
@@ -77,11 +77,8 @@ fn transmute<T1, T2>(t: T1) -> T2 {
     when !(t is builtins::SameLayoutAs<T2>) {
         compile_fail!("types do not have the same layout");
     }
-    union BitCastT<A, B> {
-        a: A,
-        b: B,
-    }
-    (BitCastT::<T1, T2> { a: t }).b
+
+    intrinsics::transmute::<T1, T2>(t)
 }
 
 /// Dereference a pointer.


### PR DESCRIPTION
Moving ZstElider to codegen stage helps with clarifying what canonical IR is (rather than the transformed one that is needed for codegen purposes and is not suitable for further compilation passes). 

This makes IR inlining and const-eval a bit cleaner. This PR also includes a few smaller improvements:
- `std::util::transmute` is now an intrinsic (with limited transmutations allowed in const eval)
- floating point arithmetic now works in const-eval
- some smaller stdlib changes