### PR TITLE
chore: Fix obsolete Node.js install method in Dockerfile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "src/alumina-boot",
     "src/alumina-boot-macros",

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,16 @@ FROM ubuntu:22.04 as environment
 ENV DEBIAN_FRONTEND noninteractive
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL sparse
 
-RUN apt-get update && apt-get install -y software-properties-common curl build-essential git
+RUN apt-get update && apt-get install -y software-properties-common curl build-essential git ca-certificates gnupg
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
-RUN apt-get install -y nodejs
+RUN mkdir -p /etc/apt/keyrings && \
+    (curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg) && \
+    (echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list) && \
+    apt-get update && \
+    apt-get install -y nodejs
 
 RUN cargo install tree-sitter-cli
 

--- a/src/alumina-boot/src/ast/expressions.rs
+++ b/src/alumina-boot/src/ast/expressions.rs
@@ -1301,11 +1301,7 @@ impl<'ast, 'src> AluminaVisitor<'src> for ExpressionVisitor<'ast, 'src> {
         } else {
             let r#macro = match expr.kind {
                 ExprKind::Macro(item, bound_params) => {
-                    args = bound_params
-                        .iter()
-                        .copied()
-                        .chain(args.into_iter())
-                        .collect();
+                    args = bound_params.iter().copied().chain(args).collect();
                     item
                 }
                 _ => return Err(CodeDiagnostic::NotAMacro).with_span_from(&self.scope, node),

--- a/src/alumina-boot/src/ast/serialization.rs
+++ b/src/alumina-boot/src/ast/serialization.rs
@@ -719,7 +719,9 @@ impl<'ast> AstSaver<'ast> {
         serializer.write_usize(seen_files.len())?;
 
         for file_id in seen_files {
-            let Some(filename) = self.global_ctx.diag().get_file_path(file_id) else { continue; };
+            let Some(filename) = self.global_ctx.diag().get_file_path(file_id) else {
+                continue;
+            };
 
             file_id.serialize(&mut serializer)?;
             filename.serialize(&mut serializer)?;

--- a/src/alumina-boot/src/codegen/elide_zst.rs
+++ b/src/alumina-boot/src/codegen/elide_zst.rs
@@ -63,7 +63,7 @@ impl<'ir> ZstElider<'ir> {
             .local_defs
             .iter()
             .copied()
-            .chain(self.additional_locals.into_iter())
+            .chain(self.additional_locals)
             .filter(|def| self.used_ids.remove(&def.id) && !def.typ.is_zero_sized())
             .collect::<Vec<_>>();
 

--- a/src/alumina-boot/src/codegen/functions.rs
+++ b/src/alumina-boot/src/codegen/functions.rs
@@ -535,7 +535,7 @@ impl<'ir, 'gen> FunctionWriter<'ir, 'gen> {
                 }
                 IntrinsicValueKind::Volatile(inner) => {
                     let Ty::Pointer(pointee, is_const) = expr.ty else {
-                         unreachable!()
+                        unreachable!()
                     };
 
                     if *is_const {

--- a/src/alumina-boot/src/ir/builder.rs
+++ b/src/alumina-boot/src/ir/builder.rs
@@ -76,7 +76,7 @@ impl<'ir> ExpressionBuilder<'ir> {
     ) -> ExprP<'ir> {
         let mut merged = Vec::new();
 
-        let ret = match self.fill_block(&mut merged, statements.into_iter()) {
+        let ret = match self.fill_block(&mut merged, statements) {
             Ok(()) => ret,
             Err(expr) => expr,
         };

--- a/src/alumina-boot/src/ir/mono.rs
+++ b/src/alumina-boot/src/ir/mono.rs
@@ -2515,7 +2515,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                             self.monomorphize_lang_item(LangItemKind::SliceConstCoerce, [*t1])?;
 
                         let func = self.exprs.function(item, rhs.span);
-                        return self.call(func, [rhs].into_iter(), lhs_typ, rhs.span);
+                        return self.call(func, [rhs], lhs_typ, rhs.span);
                     }
                     _ => {}
                 }
@@ -2530,7 +2530,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                         self.monomorphize_lang_item(LangItemKind::DynConstCoerce, [*t1_proto])?;
 
                     let func = self.exprs.function(item, rhs.span);
-                    return self.call(func, [rhs].into_iter(), lhs_typ, rhs.span);
+                    return self.call(func, [rhs], lhs_typ, rhs.span);
                 }
                 _ => {}
             },
@@ -3418,7 +3418,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
 
         self.call(
             func,
-            [lhs, rhs].into_iter(),
+            [lhs, rhs],
             item.get_function().with_backtrace(&self.diag)?.return_type,
             ast_span,
         )
@@ -3835,7 +3835,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                 let func = self.exprs.function(item, ast_span);
                 return self.call(
                     func,
-                    [expr].into_iter(),
+                    [expr],
                     item.get_function().with_backtrace(&self.diag)?.return_type,
                     ast_span,
                 );
@@ -3849,7 +3849,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                 let func = self.exprs.function(item, ast_span);
                 return self.call(
                     func,
-                    [expr].into_iter(),
+                    [expr],
                     item.get_function().with_backtrace(&self.diag)?.return_type,
                     ast_span,
                 );
@@ -4760,10 +4760,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
                 };
 
                 self.exprs.r#struct(
-                    fields
-                        .into_iter()
-                        .zip(bound_values.into_iter())
-                        .map(|(f, e)| (f.id, e)),
+                    fields.into_iter().zip(bound_values).map(|(f, e)| (f.id, e)),
                     closure_typ,
                     ast_span,
                 )
@@ -4931,7 +4928,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
             let func = self.exprs.function(item, ast_span);
             self.call(
                 func,
-                [indexee, index].into_iter(),
+                [indexee, index],
                 item.get_function().with_backtrace(&self.diag)?.return_type,
                 ast_span,
             )
@@ -5292,7 +5289,7 @@ impl<'a, 'ast, 'ir> Monomorphizer<'a, 'ast, 'ir> {
         }
 
         if lowered.iter().any(|e| e.diverges()) {
-            return Ok(self.exprs.diverges(lowered.into_iter(), ast_span));
+            return Ok(self.exprs.diverges(lowered, ast_span));
         }
 
         let element_type = first_elem_type


### PR DESCRIPTION
The curl to bash method is deprecated.

Also fixes formatting (new rustfmt) and some clippy lints.