### PR TITLE
fix: Fix uneccessary_cast lint on arm64

### DIFF
--- a/sysroot/std/ffi.alu
+++ b/sysroot/std/ffi.alu
@@ -64,6 +64,7 @@ impl CString {
     }
 
     /// @ mem::AsSlice::as_slice
+    #[allow(unnecessary_cast)]
     fn as_slice(self: &CString) -> &[u8] {
         mem::slice::from_raw(self.ptr as &u8, self.len())
     }

--- a/sysroot/std/fs/unix.alu
+++ b/sysroot/std/fs/unix.alu
@@ -483,6 +483,7 @@ fn canonicalize(path: Path) -> Result<PathBuf> {
         // We don't know the exact size of the allocated buffer, so we assume
         // that it is at least as big as the length of the string plus the null
         // terminator.
+        #[allow(unnecessary_cast)]
         let slice = mem::slice::from_raw(ret as &mut u8, len + 1);
 
         Result::ok(PathBuf { inner: StringBuf::from_raw(slice, len) })

--- a/sysroot/std/runtime/mod.alu
+++ b/sysroot/std/runtime/mod.alu
@@ -140,6 +140,7 @@ mod internal {
             let ret = when typing::matches::<arguments_of<UserMain>, (&[&[u8]])>() {
                 let args = allocate_args!(argc);
                 for i in 0usize..(argc as usize) {
+                    #[allow(unnecessary_cast)]
                     args[i] = slice::from_raw(*(argv + i) as &u8, util::cast(libc::strlen(*(argv + i))));
                 }
 


### PR DESCRIPTION
On platforms where `libc::c_char` is the same type as `u8` these threw a warning.