### PR TITLE
fix(libs): Fix Alumina Tree-sitter bindings

### DIFF
--- a/libraries/tree_sitter/mod.alu
+++ b/libraries/tree_sitter/mod.alu
@@ -49,7 +49,7 @@ struct TSNode {
 struct TSTreeCursor {
     tree: &void,
     id: &void,
-    context: [u32; 2],
+    context: [u32; 3],
 }
 
 extern "C" fn ts_parser_new() -> &mut TSParser;


### PR DESCRIPTION
This broke clang build (and hence coverage reporting) - but gcc suprisingly still worked.