### PR TITLE
fix(stdlib): Improve hashmap performance when there are many tombstones

### DIFF
--- a/sysroot/std/collections/hashmap.alu
+++ b/sysroot/std/collections/hashmap.alu
@@ -267,6 +267,7 @@ impl HashMap<K: Hashable<K, H> + Equatable<K>, V, H: Hasher<H> = DefaultHash> {
     fn _insert(self: &mut HashMap<K, V, H>, item: (K, V), grow: bool) -> Option<V> {
         let initial_index = (hash_of_val::<K, H>(item.0) as usize) % self._buckets.len();
         let index = initial_index;
+        let first_tombstone = Option::none::<usize>();
 
         loop {
             switch self._buckets[index].state {
@@ -274,6 +275,8 @@ impl HashMap<K: Hashable<K, H> + Equatable<K>, V, H: Hasher<H> = DefaultHash> {
                     if grow && self.reserve(1) {
                         return self._insert(item, false);
                     }
+
+                    index = first_tombstone.unwrap_or(index);
                     self._length += 1;
                     self._buckets[index].state = State::Occupied;
                     self._buckets[index].item = item;
@@ -282,6 +285,11 @@ impl HashMap<K: Hashable<K, H> + Equatable<K>, V, H: Hasher<H> = DefaultHash> {
                 State::Occupied => {
                     if self._buckets[index].item.0 == item.0 {
                         return Option::some(std::mem::replace(&self._buckets[index].item.1, item.1));
+                    }
+                }
+                State::Deleted => {
+                    if first_tombstone.is_none() {
+                        first_tombstone = Option::some(index);
                     }
                 }
             }


### PR DESCRIPTION
So I was reading this article: https://faultlore.com/blah/hashbrown-insert/ and I noticed that while Alumina's hashmap implementation is very similar to the pseudocode in the article, we don't remember the position of the first tomstone, but rather always insert into the first vacant spot we found. Figured why not add it. 

Benchmarked on this 
```
use std::collections::{HashMap, hashmap::State};

fn main() {
    let map: HashMap<usize, usize> = HashMap::new();
    for i in 0usize..10000000 {
        if i % 3 == 0 {
            map.remove(&(i % 1000000));
        } else {
            map.insert(i % 1000000, i);
        }
    }
}
```

## Before
```
real    0m31.618s
user    0m31.506s
sys     0m0.034s
```

## After
```
real    0m0.985s
user    0m0.966s
sys     0m0.015s
```

Oh my.

The hashmap implementation is still not good, but with this change it is distinctly less terrible.