### PR TITLE
fix(diag): Better error messages when trying to call a non-callable type

### DIFF
--- a/docs/lang_guide.md
+++ b/docs/lang_guide.md
@@ -778,6 +778,26 @@ let rotated = Point::rotate_180deg::<f64>(&point);
 // Not `Point::<f64>::rotate_180deg(&point);`
 ```
 
+If the method has the same name as a field, the field has precedence
+
+```rust
+struct Foo {
+    bar: i32
+}
+
+impl Foo {
+    fn bar(self: &Foo) -> i32 {
+        self.bar
+    }
+}
+
+let foo = Foo { bar: 42 };
+println!("{}", foo.bar()); // compile error - i32 is not callable
+
+// Method can be called explicitely using the associated function syntax
+println!("{}", Foo::bar(&foo));
+```
+
 ## Type attributes
 
 Named types can have attributes.

--- a/src/alumina-boot/src/common.rs
+++ b/src/alumina-boot/src/common.rs
@@ -142,6 +142,10 @@ pub enum CodeDiagnostic {
     TupleIndexOutOfBounds,
     #[error("function or static expected")]
     FunctionOrStaticExpectedHere,
+    #[error("`{}` is not callable", .0)]
+    NotCallable(String),
+    #[error("`{}` is not callable (hint: fields have precedence over methods, if there is a method with the same name, you can call the it explicitly with `Type::method(...)`)", .0)]
+    NotCallableFieldConfusion(String),
     #[error("unexpected generic arguments (is this a method that needs to be called?)")]
     UnexpectedGenericArgs,
     #[error("could not resolve item `{}`", .0)]

--- a/src/alumina-boot/src/ir/mono/intrinsics.rs
+++ b/src/alumina-boot/src/ir/mono/intrinsics.rs
@@ -742,11 +742,17 @@ impl<'a, 'ast, 'ir> super::Mono<'a, 'ast, 'ir> {
                     (&fn_arg_types[..], fun.return_type, callee)
                 }
                 _ => {
-                    bail!(self, CodeDiagnostic::FunctionOrStaticExpectedHere);
+                    bail!(
+                        self,
+                        CodeDiagnostic::NotCallable(self.ctx.type_name(callee.ty)?)
+                    );
                 }
             },
             _ => {
-                bail!(self, CodeDiagnostic::FunctionOrStaticExpectedHere);
+                bail!(
+                    self,
+                    CodeDiagnostic::NotCallable(self.ctx.type_name(callee.ty)?)
+                );
             }
         };
 

--- a/tests/diag/not_callable.alu
+++ b/tests/diag/not_callable.alu
@@ -1,0 +1,4 @@
+//! exit_code: 1
+fn main() {
+    1();  // diag: error(not_callable): "`i32` is not callable"
+}

--- a/tests/diag/not_callable_field_confusion.alu
+++ b/tests/diag/not_callable_field_confusion.alu
@@ -1,0 +1,15 @@
+//! exit_code: 1
+struct Foo {
+    bar: i32
+}
+
+impl Foo {
+    fn bar(self: &Foo) -> i32 {
+        self.bar
+    }
+}
+
+fn main() {
+    let foo: Foo;
+    foo.bar();  // diag: error(not_callable_field_confusion): "`i32` is not callable (hint: fields have precedence over methods, if there is a method with the same name, you can call the it explicitly with `Type::method(...)`)"
+}


### PR DESCRIPTION
Fixes #118 

The current error message when trying to call a non-callable object was pretty bad. This adds more information + adds a special case for possible field/method confusion.